### PR TITLE
Improve install docs and add FAQ to documentation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,26 @@
+
+FAQ
+===
+
+**When I run PSAMM it exits with the error "No solvers available". How can I
+fix this?**
+
+This means that PSAMM is searching for a linear programming solver but was not
+able to find one. This can occur even when the Cplex solver is installed
+because the Cplex Python-bindings have to be installed separately from the
+main Cplex package (see :ref:`install-cplex`). Also, if using a `Virtualenv`
+with Python, the Cplex Python-bindings must be installed `in the Virtualenv`.
+The bindings will `not` be available in the Virtualenv if they are installed
+globally.
+
+To check whether the Cplex Python-bindings are correctly installed use the
+following command:
+
+.. code-block:: shell
+
+    (env) $ pip list
+
+This will show a list of Python packages that are available. The package
+``cplex`` will appear in this list if the Cplex Python-bindings are correctly
+installed. If the package does `not` appear in the list, follow the instuctions
+at :ref:`install-cplex` to install the package.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    file_format
    commands
    development
+   faq
    api
    references
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,32 +2,35 @@
 Install
 =======
 
-The Python module can be installed using ``pip``. This will typically require
-*root* permissions.
-
-.. code-block:: shell
-
-    $ pip install psamm
-
-Another option that does not require *root* permissions is to use a
-`Virtualenv`_. First set up a new environment in your project directory and
-activate it:
+PSAMM can be installed using the Python package installer ``pip``. We recommend
+that you use a `Virtualenv`_ when installing PSAMM. First, create a Virtualenv
+in your project directory and activate the environment. On Linux/OSX the
+following terminal commands can be used:
 
 .. code-block:: shell
 
     $ virtualenv env
-    $ . env/bin/activate
+    $ source env/bin/activate
 
-Now the Python module can be installed in the virtual environment using the
-``pip`` command without requiring *root* permissions. When returning to the
-project, simply reactivate the environment by running the second command.
+Then, install PSAMM using the ``pip`` command:
+
+.. code-block:: shell
+
+    (env) $ pip install psamm
+
+When returning to the project from a new terminal window, simply reactivate
+the environment by running
+
+.. code-block:: shell
+
+    $ source env/bin/activate
 
 The *psamm-import* tool is developed in a separate Git repository. After
 installing PSAMM, the *psamm-import* tool can be installed using:
 
 .. code-block:: shell
 
-    $ pip install git+https://github.com/zhanglab/psamm-import.git
+    (env) $ pip install git+https://github.com/zhanglab/psamm-import.git
 
 Dependencies
 ------------
@@ -41,6 +44,8 @@ linear programming solver is not strictly required but most analyses require
 one to work. The LP solver *Cplex* is the preferred solver. The rational solver
 *QSopt_ex* does not support MILP problems which means that some analyses
 require *Cplex*.
+
+.. _install-cplex:
 
 Cplex
 -----

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -57,7 +57,13 @@ the virtual environment:
 1. Locate the directory where Cplex was installed (e.g. ``/path/to/IBM/ILOG/CPLEX_StudioXXX``).
 2. Locate the appropriate subdirectory based on your platform:
    ``cplex/python/<platform>`` (e.g. ``cplex/python/x86-64_osx``).
-3. Use ``pip`` to install the package from this directory: ``pip install /path/to/IBM/ILOG/CPLEX_StudioXXX/cplex/python/<platform>``
+3. Use ``pip`` to install the package from this directory using the following
+   command.
+
+.. code-block:: shell
+
+    (env) $ pip install \
+        /path/to/IBM/ILOG/CPLEX_StudioXXX/cplex/python/<platform>
 
 QSopt_ex
 --------
@@ -68,7 +74,7 @@ can be installed using ``pip``:
 
 .. code-block:: shell
 
-    $ pip install python-qsoptex
+    (env) $ pip install python-qsoptex
 
 .. _Virtualenv: https://virtualenv.pypa.io/
 .. _python-qsoptex: https://pypi.python.org/pypi/python-qsoptex


### PR DESCRIPTION
The install instructions are changed to more clearly highlight the procedure for installing psamm into a Virtualenv. The commands are presented in the natural order, which should help someone scanning the document. The use of a Virtualenv is not just presented as an option but as a recommendation.

A FAQ entry is added to specifically address a common Cplex install error.