### PR TITLE
Do not apply thermodynamic constraints by default

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -110,8 +110,9 @@ In this example the ``PPCK`` reaction has a minimum flux of zero and maximum
 flux of 135.3 units. The ``PTAr`` reaction has a minimum flux of 62.3 and a
 maximum of 1000 units.
 
-If the parameter ``--no-tfba`` is given, the thermodynamic constraints will not
-be included when evaluating model fluxes.
+If the parameter ``--tfba`` is given, additonal thermodynamic constraints will
+be imposed when evaluating model fluxes. This automatically removes internal
+flux loops but is much more time-consuming.
 
 Robustness (``robustness``)
 ---------------------------
@@ -284,10 +285,9 @@ reaction is part of a pathway that is incompletely modeled.
 
     $ psamm-model fluxcheck
 
-If the parameter ``--no-tfba`` is given, the thermodynamic constraints are not
-applied when considering whether reactions can take a non-zero flux. This is
-generally faster but less accurate as it allows thermodynamically infeasible
-loops to occur.
+If the parameter ``--tfba`` is given, additional thermodynamic constraints are
+imposed when considering whether reactions can take a non-zero flux. This
+automatically removes internal flux loops but is also much more time-consuming.
 
 GapFind/GapFill (``gapfill``)
 -----------------------------

--- a/psamm/commands/fluxcheck.py
+++ b/psamm/commands/fluxcheck.py
@@ -38,8 +38,8 @@ class FluxConsistencyCommand(SolverCommandMixin, Command):
             '--fastcore', help='Enable use of Fastcore algorithm',
             action='store_true')
         parser.add_argument(
-            '--no-tfba',
-            help='Disable thermodynamic constraints on flux check',
+            '--tfba',
+            help='Enable thermodynamic constraints on flux check',
             action='store_true')
         parser.add_argument(
             '--epsilon', type=float, help='Flux threshold',
@@ -74,7 +74,7 @@ class FluxConsistencyCommand(SolverCommandMixin, Command):
             inconsistent = set(fastcore.fastcc(
                 self._mm, epsilon, solver=solver))
         else:
-            enable_tfba = not self._args.no_tfba
+            enable_tfba = self._args.tfba
             if enable_tfba:
                 solver = self._get_solver(integer=True)
             else:

--- a/psamm/commands/fva.py
+++ b/psamm/commands/fva.py
@@ -25,7 +25,7 @@ class FluxVariabilityCommand(SolverCommandMixin, Command):
     @classmethod
     def init_parser(cls, parser):
         parser.add_argument(
-            '--no-tfba', help='Disable thermodynamic constraints on FVA',
+            '--tfba', help='Enable thermodynamic constraints on FVA',
             action='store_true')
         parser.add_argument('reaction', help='Reaction to maximize', nargs='?')
         super(FluxVariabilityCommand, cls).init_parser(parser)
@@ -52,7 +52,7 @@ class FluxVariabilityCommand(SolverCommandMixin, Command):
             raise CommandError('Specified reaction is not in model: {}'.format(
                 reaction))
 
-        enable_tfba = not self._args.no_tfba
+        enable_tfba = self._args.tfba
         if enable_tfba:
             solver = self._get_solver(integer=True)
         else:


### PR DESCRIPTION
Using thermodynamic constraints has the advantage of automatically removing internal flux loops. However, this comes at a price of being much more time-consuming; requiring an MILP-capable LP solver; and sometimes resulting in problems that the solver is unable to solve. This PR disables thermodynamic constraints for the commands `fva` and `fluxcheck` by default and also changes the `--no-tfba` option to `--tfba`. The option is still available to enable thermodynamic constraints when the user deems it worthwhile.

The thermodynamic constraints are disabled by default for `fba` and `robustness` in #26.