### PR TITLE
Change --reaction to --objective in commands

### DIFF
--- a/psamm/commands/randomsparse.py
+++ b/psamm/commands/randomsparse.py
@@ -43,8 +43,7 @@ class RandomSparseNetworkCommand(SolverCommandMixin, Command):
         parser.add_argument(
             '--tfba', help='Enable thermodynamic constraints on FBA',
             action='store_true', default=False)
-        parser.add_argument(
-            '--reaction', help='Reaction to maximize')
+        parser.add_argument('--objective', help='Reaction flux to maximize')
         parser.add_argument(
             'threshold', help='Threshold of max reaction flux',
             type=util.MaybeRelative)
@@ -54,8 +53,8 @@ class RandomSparseNetworkCommand(SolverCommandMixin, Command):
         super(RandomSparseNetworkCommand, cls).init_parser(parser)
 
     def run(self):
-        if self._args.reaction is not None:
-            reaction = self._args.reaction
+        if self._args.objective is not None:
+            reaction = self._args.objective
         else:
             reaction = self._model.get_biomass_reaction()
             if reaction is None:

--- a/psamm/commands/robustness.py
+++ b/psamm/commands/robustness.py
@@ -49,8 +49,7 @@ class RobustnessCommand(SolverCommandMixin, Command):
         parser.add_argument(
             '--loop-removal', help='Select type of loop removal constraints',
             choices=['none', 'tfba', 'l1min'], default='none')
-        parser.add_argument(
-            '--reaction', help='Reaction to maximize', nargs='?')
+        parser.add_argument('--objective', help='Reaction to maximize')
         parser.add_argument(
             '--all-reaction-fluxes',
             help='Print reaction flux for all model reactions',
@@ -69,8 +68,8 @@ class RobustnessCommand(SolverCommandMixin, Command):
             elif compound.id not in compound_name:
                 compound_name[compound.id] = compound.id
 
-        if self._args.reaction is not None:
-            reaction = self._args.reaction
+        if self._args.objective is not None:
+            reaction = self._args.objective
         else:
             reaction = self._model.get_biomass_reaction()
             if reaction is None:


### PR DESCRIPTION
Change `--reaction` option to `--objective` in `robustness` and `randomsparse` as suggested in #30. The commands `fba` and `fva` can also take a reaction to use as the objective but for these commands the reaction is given as a positional parameter. For this reason only the `robustness` and `randomsparse` are changed.