### PR TITLE
Combine the media in model.yaml into one medium

### DIFF
--- a/docs/file_format.rst
+++ b/docs/file_format.rst
@@ -173,6 +173,9 @@ or specified as ``-`` to use the default flux bounds::
     # CO2 exchange with production limit of 50 and default uptake limit
     co2     e       -       50
 
+Multiple medium files can be included from the main ``model.yaml`` file, and
+these will be combined to form the final medium used for the simulations.
+
 Reaction flux limits
 --------------------
 

--- a/psamm/command.py
+++ b/psamm/command.py
@@ -86,11 +86,6 @@ class Command(object):
             if reaction.equation is not None:
                 database.set_reaction(reaction.id, reaction.equation)
 
-        media = list(model.parse_media())
-        if len(media) > 1:
-            logger.warning('Only the first medium will be used')
-        medium = media[0] if len(media) > 0 else None
-
         # Warn about undefined compounds
         compounds = set()
         for compound in model.parse_compounds():
@@ -108,8 +103,8 @@ class Command(object):
                 ' of compounds'.format(compound))
 
         self._mm = MetabolicModel.load_model(
-            database, model.parse_model(), medium, model.parse_limits(),
-            v_max=model.get_default_flux_limit())
+            database, model.parse_model(), model.parse_medium(),
+            model.parse_limits(), v_max=model.get_default_flux_limit())
 
     @classmethod
     def init_parser(cls, parser):

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -216,20 +216,20 @@ class NativeModel(object):
                     self._context, self._model['limits']):
                 yield limit
 
-    def parse_media(self):
-        """Yield each medium defined in the model
+    def parse_medium(self):
+        """Yield tuples of medium compounds.
 
-        A medium is a generator of tuples of compound, reaction ID, lower, and
-        upper bound flux limits.
+        Each medium compound is a tuple of compound, reaction ID, lower and
+        upper flux limits.
         """
 
         if 'media' in self._model:
             if not isinstance(self._model['media'], list):
                 raise ParseError('Expected media to be a list')
 
-            for medium in parse_medium_list(
+            for medium_compound in parse_medium_list(
                     self._context, self._model['media']):
-                yield medium
+                yield medium_compound
 
     def parse_compounds(self):
         """Yield CompoundEntries for defined compounds"""
@@ -486,21 +486,23 @@ def parse_medium(medium_def):
         yield compound, reaction, lower, upper
 
 
-def parse_medium_list(path, media):
-    """Parse a structured list of media as obtained from a YAML file
+def parse_medium_list(path, medium):
+    """Parse a structured medium list as obtained from a YAML file.
 
-    Yields tuples of compound, lower and upper flux bounds. Path can be given
-    as a string or a context.
+    Yields tuples of compound, reaction ID, lower and upper flux bounds. Path
+    can be given as a string or a context.
     """
 
     context = FilePathContext(path)
 
-    for medium_def in media:
+    for medium_def in medium:
         if 'include' in medium_def:
             include_context = context.resolve(medium_def['include'])
-            yield parse_medium_file(include_context)
+            for medium_compound in parse_medium_file(include_context):
+                yield medium_compound
         else:
-            yield parse_medium(medium_def)
+            for medium_compound in parse_medium(medium_def):
+                yield medium_compound
 
 
 def parse_medium_yaml_file(path, f):


### PR DESCRIPTION
Fixes #37. This allows for the medium definition to be split into logical subdivisions in separate files.