### PR TITLE
Allow quadratic objectives in LP problems

### DIFF
--- a/psamm/fastcore.py
+++ b/psamm/fastcore.py
@@ -73,7 +73,7 @@ class FastcoreProblem(FluxBalanceProblem):
         cs = self._prob.add_linear_constraints(v <= -zl)
         self._temp_constr.extend(cs)
 
-        self._prob.set_linear_objective(self._prob.expr(
+        self._prob.set_objective(self._prob.expr(
             {('zl', rxnid): 1 for rxnid in reaction_subset}))
 
         self._solve()
@@ -99,7 +99,7 @@ class FastcoreProblem(FluxBalanceProblem):
         cs = self._prob.add_linear_constraints(v <= -self._epsilon)
         self._temp_constr.extend(cs)
 
-        self._prob.set_linear_objective(self._prob.expr(
+        self._prob.set_objective(self._prob.expr(
             {('z', rxnid): -weights.get(rxnid, 1) for rxnid in subset_p}))
 
         self._solve()

--- a/psamm/fluxanalysis.py
+++ b/psamm/fluxanalysis.py
@@ -166,7 +166,7 @@ class FluxBalanceProblem(object):
         have zero weight).
         """
 
-        self._prob.set_linear_objective(self.flux_expr(reaction))
+        self._prob.set_objective(self.flux_expr(reaction))
         self._solve()
 
     def flux_bound(self, reaction, direction):
@@ -214,7 +214,7 @@ class FluxBalanceProblem(object):
         objective = self._prob.expr({
             ('z', reaction_id): -weights.get(reaction_id, 1)
             for reaction_id in self._model.reactions})
-        self._prob.set_linear_objective(objective)
+        self._prob.set_objective(objective)
 
         self._solve()
 

--- a/psamm/fluxcoupling.py
+++ b/psamm/fluxcoupling.py
@@ -98,7 +98,7 @@ class FluxCouplingProblem(object):
         in that direction.
         """
         # Update objective for reaction_1
-        self._prob.set_linear_objective(self._prob.var(('vbow', reaction_1)))
+        self._prob.set_objective(self._prob.var(('vbow', reaction_1)))
 
         # Update constraint for reaction_2
         if self._reaction_constr is not None:

--- a/psamm/gapfill.py
+++ b/psamm/gapfill.py
@@ -75,7 +75,7 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
 
     objective = prob.expr(
         {('xp', compound): 1 for compound in model.compounds})
-    prob.set_linear_objective(objective)
+    prob.set_objective(objective)
 
     for compound, lhs in iteritems(binary_cons_lhs):
         prob.add_linear_constraints(lhs >= prob.var(('xp', compound)))
@@ -138,7 +138,7 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
         {('ym', reaction_id): 1 for reaction_id in core})
     objective += prob.expr(
         {('yd', reaction_id): 1 for reaction_id in database_reactions})
-    prob.set_linear_objective(objective)
+    prob.set_objective(objective)
 
     # Add constraints on core reactions
     for reaction_id in core:

--- a/psamm/lpsolver/cplex.py
+++ b/psamm/lpsolver/cplex.py
@@ -30,7 +30,7 @@ from .lp import Solver as BaseSolver
 from .lp import Constraint as BaseConstraint
 from .lp import Problem as BaseProblem
 from .lp import Result as BaseResult
-from .lp import (Expression, Relation, ObjectiveSense, VariableType,
+from .lp import (Expression, Product, Relation, ObjectiveSense, VariableType,
                  InvalidResultError)
 from ..util import LoggerFile
 
@@ -191,32 +191,60 @@ class Problem(BaseProblem):
 
         return constraints
 
-    def set_linear_objective(self, expression):
-        """Set linear objective of problem"""
+    def set_objective(self, expression):
+        """Set objective expression of the problem."""
 
         if isinstance(expression, numbers.Number):
             # Allow expressions with no variables as objective,
             # represented as a number
-            expression = Expression()
+            expression = Expression(offset=expression)
 
-        # Reset previous objective. We have to build the set of variables to
+        linear = []
+        quad = []
+
+        # Reset previous objective.
+        for var in self._non_zero_objective:
+            if var not in expression:
+                if not isinstance(var, Product):
+                    linear.append((self._variables[var], 0))
+                else:
+                    t = self._variables[var[0]], self._variables[var[1]], 0
+                    quad.append(t)
+
+        self._non_zero_objective.clear()
+
+        # Set actual objective values
+        for var, value in expression.values():
+            if not isinstance(var, Product):
+                self._non_zero_objective.add(var)
+                linear.append((self._variables[var], value))
+            else:
+                if len(var) > 2:
+                    raise ValueError('Invalid objective: {}'.format(var))
+                self._non_zero_objective.add(var)
+                var1 = self._variables[var[0]]
+                var2 = self._variables[var[1]]
+                if var1 == var2:
+                    value *= 2
+                quad.append((var1, var2, value))
+
+        # We have to build the set of variables to
         # update so that we can avoid calling set_linear if the set is empty.
         # This is due to set_linear failing if the input is an empty
         # iterable.
-        reset_vars = set(
-            self._variables[var] for var in self._non_zero_objective
-            if var not in expression)
-        if len(reset_vars) > 0:
-            self._cp.objective.set_linear((var, 0) for var in reset_vars)
+        if len(linear) > 0:
+            self._cp.objective.set_linear(linear)
+        if len(quad) > 0:
+            self._cp.objective.set_quadratic_coefficients(quad)
 
-        # Set actual objective values
-        if len(expression.values()) > 0:
-            self._cp.objective.set_linear(
-                (self._variables[var], value)
-                for var, value in expression.values())
+        self._cp.objective.set_offset(expression.offset)
 
-        # Keep track of new non-zeros
-        self._non_zero_objective = set(expression.variables())
+    set_linear_objective = set_objective
+    """Set objective of the problem.
+
+    .. deprecated:: 0.19
+       Use :meth:`set_objective` instead.
+    """
 
     def set_objective_sense(self, sense):
         """Set type of problem (maximize or minimize)"""
@@ -317,15 +345,26 @@ class Result(BaseResult):
 
         return status == cp.solution.status.unbounded
 
+    def _get_value(self, var):
+        return self._problem._cp.solution.get_values(
+            self._problem._variables[var])
+
     def get_value(self, expression):
         """Return value of expression"""
 
         self._check_valid()
         if isinstance(expression, Expression):
-            return sum(self._problem._cp.solution.get_values(
-                self._problem._variables[var])*value
-                for var, value in expression.values())
+            total = expression.offset
+            for var, value in expression.values():
+                if not isinstance(var, Product):
+                    total += self._get_value(var) * value
+                else:
+                    t = value
+                    for v in var:
+                        t *= self._get_value(v)
+                    total += t
+            return total
         elif expression not in self._problem._variables:
             raise ValueError('Unknown expression: {}'.format(expression))
-        return self._problem._cp.solution.get_values(
-            self._problem._variables[expression])
+
+        return self._get_value(expression)

--- a/psamm/lpsolver/cplex.py
+++ b/psamm/lpsolver/cplex.py
@@ -346,25 +346,15 @@ class Result(BaseResult):
         return status == cp.solution.status.unbounded
 
     def _get_value(self, var):
+        """Return value of variable in solution."""
         return self._problem._cp.solution.get_values(
             self._problem._variables[var])
 
+    def _has_variable(self, var):
+        """Whether variable exists in the solution."""
+        return self._problem.has_variable(var)
+
     def get_value(self, expression):
-        """Return value of expression"""
-
+        """Return value of expression."""
         self._check_valid()
-        if isinstance(expression, Expression):
-            total = expression.offset
-            for var, value in expression.values():
-                if not isinstance(var, Product):
-                    total += self._get_value(var) * value
-                else:
-                    t = value
-                    for v in var:
-                        t *= self._get_value(v)
-                    total += t
-            return total
-        elif expression not in self._problem._variables:
-            raise ValueError('Unknown expression: {}'.format(expression))
-
-        return self._get_value(expression)
+        return super(Result, self).get_value(expression)

--- a/psamm/lpsolver/generic.py
+++ b/psamm/lpsolver/generic.py
@@ -39,6 +39,7 @@ try:
         'class': cplex.Solver,
         'name': 'cplex',
         'integer': True,
+        'quadratic': True,
         'rational': False,
         'priority': 10
     })
@@ -52,6 +53,7 @@ try:
         'class': qsoptex.Solver,
         'name': 'qsoptex',
         'integer': False,
+        'quadratic': False,
         'rational': True,
         'priority': 5
     })
@@ -65,6 +67,7 @@ try:
         'class': gurobi.Solver,
         'name': 'gurobi',
         'integer': True,
+        'quadratic': False,
         'rational': False,
         'priority': 9
     })
@@ -80,7 +83,7 @@ def filter_solvers(solvers, requirements):
     """Yield solvers that fullfil the requirements."""
     for solver in solvers:
         for req, value in iteritems(requirements):
-            if (req in ('integer', 'rational', 'name') and
+            if (req in ('integer', 'quadratic', 'rational', 'name') and
                     (req not in solver or solver[req] != value)):
                 break
         else:
@@ -95,6 +98,7 @@ class Solver(BaseSolver):
 
     - `integer`: Use a solver that support integer variables (MILP)
     - `rational`: Use a solver that returns rational results
+    - `quadratic`: Use a solver that supports quadratic objective/constraints
     - `name`: Select a specific solver based on the name
     """
 
@@ -146,7 +150,7 @@ def parse_solver_setting(s):
     except ValueError:
         key, value = s, 'yes'
 
-    if key in ('rational', 'integer'):
+    if key in ('rational', 'integer', 'quadratic'):
         value = value.lower() in ('1', 'yes', 'true', 'on')
     elif key in ('threads',):
         value = int(value)
@@ -209,6 +213,8 @@ def list_solvers(args=None):
             print('Priority: {}'.format(solver['priority']))
             print('MILP (integer) problem support: {}'.format(
                 solver['integer']))
+            print('QP (quadratic) problem support: {}'.format(
+                solver['quadratic']))
             print('Rational solution: {}'.format(solver['rational']))
             print('Class: {}'.format(solver['class']))
             print()

--- a/psamm/lpsolver/gurobi.py
+++ b/psamm/lpsolver/gurobi.py
@@ -177,7 +177,7 @@ class Problem(BaseProblem):
 
         return constraints
 
-    def set_linear_objective(self, expression):
+    def set_objective(self, expression):
         """Set linear objective of problem."""
 
         if isinstance(expression, numbers.Number):
@@ -187,6 +187,13 @@ class Problem(BaseProblem):
 
         self._p.setObjective(
             self._grb_expr_from_value_set(expression.values()))
+
+    set_linear_objective = set_objective
+    """Set objective of the problem.
+
+    .. deprecated:: 0.19
+       Use :meth:`set_objective` instead.
+    """
 
     def set_objective_sense(self, sense):
         """Set type of problem (maximize or minimize)."""

--- a/psamm/lpsolver/gurobi.py
+++ b/psamm/lpsolver/gurobi.py
@@ -278,15 +278,16 @@ class Result(BaseResult):
         self._check_valid()
         return str(self._problem._p.Status)
 
+    def _get_value(self, var):
+        """Return value of variable in solution."""
+        return self._problem._p.getVarByName(self._problem._variables[var]).x
+
+    def _has_variable(self, var):
+        """Whether variable exists in the solution."""
+        return self._problem.has_variable(var)
+
     def get_value(self, expression):
         """Return value of expression."""
 
         self._check_valid()
-        if isinstance(expression, Expression):
-            return sum(self._problem._p.getVarByName(
-                self._problem._variables[var]).x * value
-                for var, value in expression.values())
-        elif expression not in self._problem._variables:
-            raise ValueError('Unknown expression: {}'.format(expression))
-        return self._problem._p.getVarByName(
-            self._problem._variables[expression]).x
+        return super(Result, self).get_value(expression)

--- a/psamm/lpsolver/lp.py
+++ b/psamm/lpsolver/lp.py
@@ -536,10 +536,15 @@ class Problem(object):
         """
 
     @abc.abstractmethod
-    def set_linear_objective(self, expression):
-        """Set linear objective of the problem to the given
-        :class:`.Expression`.
-        """
+    def set_objective(self, expression):
+        """Set objective of the problem to the given :class:`.Expression`."""
+
+    set_linear_objective = set_objective
+    """Set objective of the problem.
+
+    .. deprecated:: 0.19
+       Use :meth:`set_objective` instead.
+    """
 
     @abc.abstractmethod
     def set_objective_sense(self, sense):

--- a/psamm/lpsolver/qsoptex.py
+++ b/psamm/lpsolver/qsoptex.py
@@ -235,14 +235,16 @@ class Result(BaseResult):
         self._check_valid()
         return 'Status: {}'.format(self._problem._p.get_status())
 
+    def _get_value(self, var):
+        """Return value of variable in solution."""
+        return self._problem._p.get_value(self._problem._variables[var])
+
+    def _has_variable(self, var):
+        """Whether variable exists in the solution."""
+        return self._problem.has_variable(var)
+
     def get_value(self, expression):
         """Return value of expression"""
 
         self._check_valid()
-        if isinstance(expression, Expression):
-            return sum(self._problem._p.get_value(
-                self._problem._variables[var])*value
-                for var, value in expression.values())
-        elif expression not in self._problem._variables:
-            raise ValueError('Unknown expression: {}'.format(expression))
-        return self._problem._p.get_value(self._problem._variables[expression])
+        return super(Result, self).get_value(expression)

--- a/psamm/lpsolver/qsoptex.py
+++ b/psamm/lpsolver/qsoptex.py
@@ -143,7 +143,7 @@ class Problem(BaseProblem):
 
         return constraints
 
-    def set_linear_objective(self, expression):
+    def set_objective(self, expression):
         """Set linear objective of problem"""
 
         if isinstance(expression, numbers.Number):
@@ -154,6 +154,13 @@ class Problem(BaseProblem):
         self._p.set_linear_objective(
             (lp_name, expression.value(var))
             for var, lp_name in iteritems(self._variables))
+
+    set_linear_objective = set_objective
+    """Set objective of the problem.
+
+    .. deprecated:: 0.19
+       Use :meth:`set_objective` instead.
+    """
 
     def set_objective_sense(self, sense):
         """Set type of problem (maximize or minimize)"""

--- a/psamm/massconsistency.py
+++ b/psamm/massconsistency.py
@@ -59,7 +59,7 @@ def is_consistent(database, solver, exchange=set(), zeromass=set()):
         else:
             prob.define(('m', compound), lower=0, upper=0)
 
-    prob.set_linear_objective(prob.expr(
+    prob.set_objective(prob.expr(
         {('m', compound): 1 for compound in compound_set}))
 
     # Define constraints
@@ -110,7 +110,7 @@ def check_reaction_consistency(database, solver, exchange=set(),
     objective = prob.expr(
         {('z', reaction_id): weights.get(reaction_id, 1)
          for reaction_id in database.reactions})
-    prob.set_linear_objective(objective)
+    prob.set_objective(objective)
 
     r = prob.set(('r', reaction_id) for reaction_id in database.reactions)
     z = prob.set(('z', reaction_id) for reaction_id in database.reactions)
@@ -174,7 +174,7 @@ def check_compound_consistency(database, solver, exchange=set(),
     # Define z variables
     prob.define(*(('z', compound) for compound in compound_set),
                 lower=0, upper=1)
-    prob.set_linear_objective(prob.expr(
+    prob.set_objective(prob.expr(
         {('z', compound): 1 for compound in compound_set}))
 
     z = prob.set(('z', compound) for compound in compound_set)

--- a/psamm/tests/test_cplex.py
+++ b/psamm/tests/test_cplex.py
@@ -45,21 +45,36 @@ class TestCplexProblem(unittest.TestCase):
         expr = -prob.var(('x', 1)) + 2 * prob.var(('x', 2))
         self.assertEqual(str(expr), "-('x', 1) + 2*('x', 2)")
 
-    def test_objective_reset_on_set_linear_objective(self):
+    def test_objective_reset_on_set_objective(self):
         prob = self.solver.create_problem()
         prob.define('x', 'y', lower=0, upper=10)
         prob.add_linear_constraints(prob.var('x') + prob.var('y') <= 12)
         prob.set_objective_sense(lp.ObjectiveSense.Maximize)
 
         # Solve first time, maximize x
-        prob.set_linear_objective(2*prob.var('x'))
+        prob.set_objective(2*prob.var('x'))
         result = prob.solve()
         self.assertAlmostEqual(result.get_value('x'), 10)
 
         # Solve second time, maximize y
         # If the objective is not properly cleared,
         # the second solve will still maximize x.
-        prob.set_linear_objective(prob.var('y'))
+        prob.set_objective(prob.var('y'))
+        result = prob.solve()
+        self.assertAlmostEqual(result.get_value('y'), 10)
+
+    def test_quadratic_objective(self):
+        prob = self.solver.create_problem()
+        prob.define('x', 'y', lower=0, upper=10)
+        prob.add_linear_constraints(prob.var('x') + prob.var('y') <= 12)
+        prob.set_objective_sense(lp.ObjectiveSense.Maximize)
+
+        prob.set_objective(-prob.var('x')**2 + 5*prob.var('x'))
+        result = prob.solve()
+        self.assertAlmostEqual(result.get_value('x'), 2.5)
+
+        # Solve second time, maximize y
+        prob.set_objective(prob.var('y'))
         result = prob.solve()
         self.assertAlmostEqual(result.get_value('y'), 10)
 

--- a/psamm/tests/test_lpsolver_lp.py
+++ b/psamm/tests/test_lpsolver_lp.py
@@ -118,6 +118,98 @@ class TestExpression(unittest.TestCase):
         e *= float('inf')
         self.assertTrue(math.isnan(e.offset))
 
+    def test_multiply_expression_and_simple_expression(self):
+        e1 = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e2 = lp.Expression({'x1': 1})
+        e = e1 * e2
+        self.assertEqual(e.offset, 0)
+        self.assertEqual(dict(e.values()), {
+            lp.Product(['x1', 'x1']): -5,
+            lp.Product(['x1', 'x2']): 3,
+            'x1': 10
+        })
+
+    def test_multiply_expression_and_expression(self):
+        e1 = lp.Expression({'x1': 1, 'x2': 2, 'x3': 3}, offset=4)
+        e2 = lp.Expression({'x2': 4, 'x4': 5}, offset=-5)
+        e = e1 * e2
+        self.assertEqual(e.offset, -20)
+        self.assertEqual(dict(e.values()), {
+            lp.Product(['x1', 'x2']): 4,
+            lp.Product(['x2', 'x2']): 8,
+            lp.Product(['x2', 'x3']): 12,
+            lp.Product(['x1', 'x4']): 5,
+            lp.Product(['x2', 'x4']): 10,
+            lp.Product(['x3', 'x4']): 15,
+            'x1': -5,
+            'x2': 6,
+            'x3': -15,
+            'x4': 20
+        })
+
+    def test_multiply_expression_and_expression_in_place(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e *= lp.Expression({'x1': 1})
+        self.assertEqual(e.offset, 0)
+        self.assertEqual(dict(e.values()), {
+            lp.Product(['x1', 'x1']): -5,
+            lp.Product(['x1', 'x2']): 3,
+            'x1': 10
+        })
+
+    def test_expression_pow_negative(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        with self.assertRaises(ValueError):
+            e1 = e**-2
+
+    def test_expression_pow_neagtive_in_place(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        with self.assertRaises(ValueError):
+            e **= -2
+
+    def test_expression_pow_zero(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e1 = e**0
+        self.assertEqual(e1.offset, 1)
+        self.assertEqual(dict(e1.values()), {})
+
+    def test_expression_pow_zero_in_place(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e **= 0
+        self.assertEqual(e.offset, 1)
+        self.assertEqual(dict(e.values()), {})
+
+    def test_expression_pow_one(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e1 = e**1
+        self.assertEqual(e1.offset, e.offset)
+        self.assertEqual(dict(e1.values()), dict(e.values()))
+
+    def test_expression_pow_one_in_place(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e **= 1
+        self.assertEqual(e.offset, 10)
+        self.assertEqual(dict(e.values()), {'x1': -5, 'x2': 3})
+
+    def test_expression_pow_two(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e1 = e**2
+        e2 = e*e
+        self.assertEqual(e1.offset, e2.offset)
+        self.assertEqual(dict(e1.values()), dict(e2.values()))
+
+    def test_expression_pow_two_in_place(self):
+        e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
+        e **= 2
+        self.assertEqual(e.offset, 100)
+        self.assertEqual(dict(e.values()), {
+            lp.Product(['x1', 'x1']): 25,
+            lp.Product(['x1', 'x2']): -30,
+            lp.Product(['x2', 'x2']): 9,
+            'x1': -100,
+            'x2': 60
+        })
+
     def test_negate_expression(self):
         e = lp.Expression({'x1': 52}, -32)
         e1 = -e
@@ -128,6 +220,10 @@ class TestExpression(unittest.TestCase):
         e = lp.Expression({'x1': -4, 'x2': 100, 'x3': 1}, 42)
         self.assertEqual(str(e), '-4*x1 + 100*x2 + x3 + 42')
 
+    def test_expression_with_product_to_string(self):
+        e = lp.Expression({'x1': -4, lp.Product(['x1', 'x2']): 2}, 12)
+        self.assertEqual(str(e), '-4*x1 + 2*x1*x2 + 12')
+
     def test_expression_with_tuple_vars_to_string(self):
         e = lp.Expression({('v', 1): 1}, -1)
         self.assertEqual(str(e), "('v', 1) - 1")
@@ -136,6 +232,11 @@ class TestExpression(unittest.TestCase):
         e = lp.Expression({'x1': 10, 'x2': -5})
         self.assertIn('x1', e)
         self.assertNotIn('x3', e)
+
+    def test_expression_contains_product(self):
+        e = lp.Expression({lp.Product(['x1', 'x1']): -1})
+        self.assertIn(lp.Product(['x1', 'x1']), e)
+        self.assertNotIn('x1', e)
 
 
 class TestRelation(unittest.TestCase):


### PR DESCRIPTION
Changes the LP solver interface to allow quadratic expressions to be constructed and set as the objective. Support is implemented in `cplex`. The method `set_linear_objective` was renamed to `set_objective` since the same method is used to set both types of objectives (or mixed objectives).

- [x] `gurobi` support.