### PR TITLE
chargecheck: Fix printing reaction IDs

### DIFF
--- a/psamm/commands/chargecheck.py
+++ b/psamm/commands/chargecheck.py
@@ -82,7 +82,7 @@ class ChargeBalanceCommand(Command):
                 unbalanced += 1
                 rxt = reaction.equation.translated_compounds(
                     lambda x: compound_name.get(x, x))
-                print('{}\t{}\t{}'.format(reaction, charge, rxt))
+                print('{}\t{}\t{}'.format(reaction.id, charge, rxt))
 
         logger.info('Unbalanced reactions: {}/{}'.format(unbalanced, count))
         logger.info('Unchecked reactions due to missing charge: {}/{}'.format(


### PR DESCRIPTION
When psamm output charge check result, instead of printing the reaction object, just printing the reaction IDs.