### PR TITLE
Make Atoms singletons and simplify access

### DIFF
--- a/psamm/formula.py
+++ b/psamm/formula.py
@@ -79,13 +79,40 @@ class FormulaElement(object):
         return self
 
 
+class _AtomType(type):
+    """Metaclass that gives the Atom class properties for each element.
+
+    A class based on this metaclass (i.e. :class:`.Atom`) will have a
+    property for each element which contains an instance of that element.
+    """
+
+    _ELEMENTS = set([
+        'H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 'Mg', 'Al',
+        'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 'Ti', 'V', 'Cr', 'Mn',
+        'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb',
+        'Sr', 'Y', 'Zr', 'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In',
+        'Sn', 'Sb', 'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm',
+        'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 'Hf', 'Ta',
+        'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 'Pb', 'Bi', 'Po', 'At',
+        'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 'U', 'Np', 'Pu', 'Am', 'Cm', 'Bk',
+        'Cf', 'Es', 'Fm', 'Md', 'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt',
+        'Ds', 'Rg', 'Cn', 'Uut', 'Fl', 'Uup', 'Lv', 'Uus', 'Uuo'
+    ])
+
+    def __getattribute__(self, name):
+        if name in _AtomType._ELEMENTS:
+            return self(name)
+        return super(_AtomType, self).__getattribute__(name)
+
+
 @six.python_2_unicode_compatible
 @functools.total_ordering
+@six.add_metaclass(_AtomType)
 class Atom(FormulaElement):
     """Represent an atom in a chemical formula
 
-    >>> hydrogen = Atom('H')
-    >>> oxygen = Atom('O')
+    >>> hydrogen = Atom.H
+    >>> oxygen = Atom.O
     >>> str(oxygen | 2*hydrogen)
     'H2O'
     """
@@ -97,7 +124,7 @@ class Atom(FormulaElement):
     def symbol(self):
         """Atom symbol
 
-        >>> Atom('H').symbol
+        >>> Atom.H.symbol
         'H'
         """
 
@@ -164,7 +191,7 @@ class Formula(FormulaElement):
     This is represented as a number of
     :class:`FormulaElements <.FormulaElement>` with associated counts.
 
-    >>> f = Formula({Atom('C'): 6, Atom('H'): 12, Atom('O'): 6})
+    >>> f = Formula({Atom.C: 6, Atom.H: 12, Atom.O: 6})
     >>> str(f)
     'C6H12O6'
     """
@@ -235,7 +262,7 @@ class Formula(FormulaElement):
     def __str__(self):
         """Return formula represented using Hill notation system
 
-        >>> str(Formula({Atom('C'): 6, Atom('H'): 12, Atom('O'): 6}))
+        >>> str(Formula({Atom.C: 6, Atom.H: 12, Atom.O: 6}))
         'C6H12O6'
         """
 
@@ -249,13 +276,13 @@ class Formula(FormulaElement):
                 else:
                     return 2, None
 
-            if Atom('C') in values:
-                yield Atom('C'), values[Atom('C')]
-                if Atom('H') in values:
-                    yield Atom('H'), values[Atom('H')]
+            if Atom.C in values:
+                yield Atom.C, values[Atom.C]
+                if Atom.H in values:
+                    yield Atom.H, values[Atom.H]
                 for element, value in sorted(
                         iteritems(values), key=element_sort_key):
-                    if element not in (Atom('C'), Atom('H')):
+                    if element not in (Atom.C, Atom.H):
                         yield element, value
             else:
                 for element, value in sorted(

--- a/psamm/formula.py
+++ b/psamm/formula.py
@@ -82,8 +82,9 @@ class FormulaElement(object):
 class _AtomType(type):
     """Metaclass that gives the Atom class properties for each element.
 
-    A class based on this metaclass (i.e. :class:`.Atom`) will have a
-    property for each element which contains an instance of that element.
+    A class based on this metaclass (i.e. :class:`.Atom`) will have singleton
+    elements with each name, and will have a property for each element which
+    contains the instance for that element.
     """
 
     _ELEMENTS = set([
@@ -98,6 +99,15 @@ class _AtomType(type):
         'Cf', 'Es', 'Fm', 'Md', 'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt',
         'Ds', 'Rg', 'Cn', 'Uut', 'Fl', 'Uup', 'Lv', 'Uus', 'Uuo'
     ])
+
+    _instances = {}
+
+    def __call__(self, name, *args, **kwargs):
+        instances = _AtomType._instances.setdefault(self, {})
+        if name not in instances:
+            instances[name] = super(_AtomType, self).__call__(
+                name, *args, **kwargs)
+        return instances[name]
 
     def __getattribute__(self, name):
         if name in _AtomType._ELEMENTS:

--- a/psamm/tests/test_formula.py
+++ b/psamm/tests/test_formula.py
@@ -59,6 +59,14 @@ class TestAtom(unittest.TestCase):
         a = Atom('Zn')
         self.assertEqual(a.symbol, 'Zn')
 
+    def test_atom_symbol_non_standard(self):
+        a = Atom('X')
+        self.assertEqual(a.symbol, 'X')
+
+    def test_atom_singleton_property(self):
+        a = Atom.C
+        self.assertEqual(a.symbol, 'C')
+
     def test_atom_to_string(self):
         a = Atom('C')
         self.assertEqual(str(a), 'C')
@@ -69,9 +77,8 @@ class TestAtom(unittest.TestCase):
 
     def test_atom_equals(self):
         a1 = Atom('H')
-        a2 = Atom('Zn')
-        self.assertEqual(a1, a1)
-        self.assertNotEqual(a1, a2)
+        self.assertEqual(a1, Atom.H)
+        self.assertNotEqual(a1, Atom.Zn)
 
     def test_atom_ordered(self):
         a1 = Atom('H')
@@ -83,70 +90,70 @@ class TestAtom(unittest.TestCase):
 
 class TestFormula(unittest.TestCase):
     def test_formula_merge_same_formulas_with_same_atoms(self):
-        f = Formula({Atom('H'): 2, Atom('O'): 1}) | Formula({Atom('N'): 1, Atom('O'): 2})
-        self.assertEqual(f, Formula({Atom('H'): 2, Atom('N'): 1, Atom('O'): 3}))
+        f = Formula({Atom.H: 2, Atom.O: 1}) | Formula({Atom.N: 1, Atom.O: 2})
+        self.assertEqual(f, Formula({Atom.H: 2, Atom.N: 1, Atom.O: 3}))
 
     def test_formula_merge_formulas_that_cancel_out(self):
-        f = Formula({Atom('H'): 3}) | Formula({Atom('H'): -3})
+        f = Formula({Atom.H: 3}) | Formula({Atom.H: -3})
         self.assertEqual(f, Formula())
 
     def test_formula_multiply_number(self):
-        f = Formula({Atom('H'): 2, Atom('O'): 1}) * 4
-        self.assertEqual(f, Formula({Atom('H'): 8, Atom('O'): 4}))
+        f = Formula({Atom.H: 2, Atom.O: 1}) * 4
+        self.assertEqual(f, Formula({Atom.H: 8, Atom.O: 4}))
 
     def test_formula_multiply_one(self):
-        f = Formula({Atom('H'): 2, Atom('O'): 1}) * 1
+        f = Formula({Atom.H: 2, Atom.O: 1}) * 1
         self.assertEqual(f, f)
 
     def test_formula_multiply_zero(self):
-        f = Formula({Atom('H'): 2, Atom('O'): 1}) * 0
+        f = Formula({Atom.H: 2, Atom.O: 1}) * 0
         self.assertEqual(f, Formula())
 
     def test_formula_right_multiply_number(self):
-        f = 2 * Formula({Atom('H'): 2, Atom('O'): 1})
-        self.assertEqual(f, Formula({Atom('H'): 4, Atom('O'): 2}))
+        f = 2 * Formula({Atom.H: 2, Atom.O: 1})
+        self.assertEqual(f, Formula({Atom.H: 4, Atom.O: 2}))
 
     def test_formula_repeat(self):
-        f = Formula({Atom('H'): 2, Atom('O'): 1}).repeat(4)
-        self.assertEqual(f, Formula({ Formula({Atom('H'): 2, Atom('O'): 1}): 4 }))
+        f = Formula({Atom.H: 2, Atom.O: 1}).repeat(4)
+        self.assertEqual(f, Formula({Formula({Atom.H: 2, Atom.O: 1}): 4}))
 
     def test_formula_equals_other_formula(self):
-        f = Formula({Atom('H'): 2, Atom('O'): 1})
-        self.assertEqual(f, Formula({Atom('O'): 1, Atom('H'): 2}))
+        f = Formula({Atom.H: 2, Atom.O: 1})
+        self.assertEqual(f, Formula({Atom.O: 1, Atom.H: 2}))
 
     def test_formula_not_equals_other_with_distinct_elements(self):
-        f = Formula({Atom('Au'): 1})
-        self.assertNotEqual(f, Formula({Atom('Ag'): 1}))
+        f = Formula({Atom.Au: 1})
+        self.assertNotEqual(f, Formula({Atom.Ag: 1}))
 
     def test_formula_not_equals_other_with_different_number(self):
-        f = Formula({Atom('Au'): 1})
-        self.assertNotEqual(f, Formula({Atom('Au'): 2}))
+        f = Formula({Atom.Au: 1})
+        self.assertNotEqual(f, Formula({Atom.Au: 2}))
 
     def test_formula_items(self):
-        f = Formula({Atom('H'): 12, Atom('C'): 6, Atom('O'): 6})
+        f = Formula({Atom.H: 12, Atom.C: 6, Atom.O: 6})
         self.assertEqual(dict(f.items()), {
-            Atom('C'): 6,
-            Atom('H'): 12,
-            Atom('O'): 6
+            Atom.C: 6,
+            Atom.H: 12,
+            Atom.O: 6
         })
 
     def test_formula_contains(self):
-        f = Formula({Atom('H'): 12, Atom('C'): 6, Atom('O'): 6})
-        self.assertIn(Atom('C'), f)
-        self.assertNotIn(Atom('Ag'), f)
+        f = Formula({Atom.H: 12, Atom.C: 6, Atom.O: 6})
+        self.assertIn(Atom.C, f)
+        self.assertNotIn(Atom.Ag, f)
 
     def test_formula_to_string(self):
-        f = Formula({Atom('H'): 12, Atom('C'): 6, Atom('O'): 6})
+        f = Formula({Atom.H: 12, Atom.C: 6, Atom.O: 6})
         self.assertEqual(str(f), 'C6H12O6')
 
     def test_formula_to_string_with_group(self):
         f = Formula({
-            Atom('C'): 1,
-            Atom('H'): 3,
-            Formula({Atom('C'): 1, Atom('H'): 2}): 14,
+            Atom.C: 1,
+            Atom.H: 3,
+            Formula({Atom.C: 1, Atom.H: 2}): 14,
             Formula({
-                Atom('C'): 1, Atom('O'): 1,
-                Formula({Atom('H'): 1, Atom('O'): 1}): 1
+                Atom.C: 1, Atom.O: 1,
+                Formula({Atom.H: 1, Atom.O: 1}): 1
             }): 1
         })
         # Ideally: self.assertEqual(str(f), 'CH3(CH2)14COOH')
@@ -155,18 +162,18 @@ class TestFormula(unittest.TestCase):
 
     def test_formula_flattened(self):
         f = Formula({
-            Atom('C'): 1,
-            Atom('H'): 3,
-            Formula({Atom('C'): 1, Atom('H'): 2}): 14,
+            Atom.C: 1,
+            Atom.H: 3,
+            Formula({Atom.C: 1, Atom.H: 2}): 14,
             Formula({
-                Atom('C'): 1, Atom('O'): 1,
-                Formula({Atom('H'): 1, Atom('O'): 1}): 1
+                Atom.C: 1, Atom.O: 1,
+                Formula({Atom.H: 1, Atom.O: 1}): 1
             }): 1
         })
         self.assertEqual(f.flattened(), Formula({
-            Atom('C'): 16,
-            Atom('H'): 32,
-            Atom('O'): 2
+            Atom.C: 16,
+            Atom.H: 32,
+            Atom.O: 2
         }))
 
     def test_formula_substitute_non_positive(self):
@@ -189,75 +196,83 @@ class TestFormula(unittest.TestCase):
     def test_formula_balance_missing_on_one_side(self):
         f1, f2 = Formula.balance(Formula.parse('H2O'), Formula.parse('OH'))
         self.assertEqual(f1, Formula())
-        self.assertEqual(f2, Formula({Atom('H'): 1}))
+        self.assertEqual(f2, Formula({Atom.H: 1}))
 
     def test_formula_balance_missing_on_both_sides(self):
-        f1, f2 = Formula.balance(Formula.parse('C3H6OH'), Formula.parse('CH6O2'))
-        self.assertEqual(f1, Formula({Atom('O'): 1}))
-        self.assertEqual(f2, Formula({Atom('C'): 2, Atom('H'): 1}))
+        f1, f2 = Formula.balance(
+            Formula.parse('C3H6OH'), Formula.parse('CH6O2'))
+        self.assertEqual(f1, Formula({Atom.O: 1}))
+        self.assertEqual(f2, Formula({Atom.C: 2, Atom.H: 1}))
 
     def test_formula_balance_subgroups_cancel_out(self):
-        f1, f2 = Formula.balance(Formula.parse('H2(CH2)n'), Formula.parse('CH3O(CH2)n'))
-        self.assertEqual(f1, Formula({Atom('C'): 1, Atom('H'): 1, Atom('O'): 1}))
+        f1, f2 = Formula.balance(
+            Formula.parse('H2(CH2)n'), Formula.parse('CH3O(CH2)n'))
+        self.assertEqual(f1, Formula({Atom.C: 1, Atom.H: 1, Atom.O: 1}))
         self.assertEqual(f2, Formula())
 
 
 class TestFormulaParser(unittest.TestCase):
     def test_formula_parse_with_final_digit(self):
         f = Formula.parse('H2O2')
-        self.assertEqual(f, Formula({Atom('H'): 2, Atom('O'): 2}))
+        self.assertEqual(f, Formula({Atom.H: 2, Atom.O: 2}))
 
     def test_formula_parse_with_implicit_final_digit(self):
         f = Formula.parse('H2O')
-        self.assertEqual(f, Formula({Atom('H'): 2, Atom('O'): 1}))
+        self.assertEqual(f, Formula({Atom.H: 2, Atom.O: 1}))
 
     def test_formula_parse_with_implicit_digit(self):
         f = Formula.parse('C2H5NO2')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('H'): 5, Atom('N'): 1, Atom('O'): 2}))
+        self.assertEqual(f, Formula(
+            {Atom.C: 2, Atom.H: 5, Atom.N: 1, Atom.O: 2}))
 
     def test_formula_parse_with_wide_element(self):
         f = Formula.parse('ZnO')
-        self.assertEqual(f, Formula({Atom('Zn'): 1, Atom('O'): 1}))
+        self.assertEqual(f, Formula({Atom.Zn: 1, Atom.O: 1}))
 
     def test_formula_parse_with_wide_count(self):
         f = Formula.parse('C6H10O2')
-        self.assertEqual(f, Formula({Atom('C'): 6, Atom('H'): 10, Atom('O'): 2}))
+        self.assertEqual(f, Formula({Atom.C: 6, Atom.H: 10, Atom.O: 2}))
 
     def test_formula_parse_with_implicitly_counted_subgroup(self):
         f = Formula.parse('C2H6O2(CH)')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('H'): 6, Atom('O'): 2,
-                                      Formula({Atom('C'): 1, Atom('H'): 1}): 1}))
+        self.assertEqual(f, Formula({
+            Atom.C: 2, Atom.H: 6, Atom.O: 2,
+            Formula({Atom.C: 1, Atom.H: 1}): 1}))
 
     def test_formula_parse_with_counted_subgroup(self):
         f = Formula.parse('C2H6O2(CH)2')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('H'): 6, Atom('O'): 2,
-                                      Formula({Atom('C'): 1, Atom('H'): 1}): 2}))
+        self.assertEqual(f, Formula({
+            Atom.C: 2, Atom.H: 6, Atom.O: 2,
+            Formula({Atom.C: 1, Atom.H: 1}): 2}))
 
     def test_formula_parse_with_two_identical_counted_subgroups(self):
         f = Formula.parse('C2H6O2(CH)2(CH)2')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('H'): 6, Atom('O'): 2,
-                                      Formula({Atom('C'): 1, Atom('H'): 1}): 4}))
+        self.assertEqual(f, Formula({
+            Atom.C: 2, Atom.H: 6, Atom.O: 2,
+            Formula({Atom.C: 1, Atom.H: 1}): 4}))
 
     def test_formula_parse_with_two_distinct_counted_subgroups(self):
         f = Formula.parse('C2H6O2(CH)2(CH2)2')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('H'): 6, Atom('O'): 2,
-                                      Formula({Atom('C'): 1, Atom('H'): 1}): 2,
-                                      Formula({Atom('C'): 1, Atom('H'): 2}): 2}))
+        self.assertEqual(f, Formula({
+            Atom.C: 2, Atom.H: 6, Atom.O: 2,
+            Formula({Atom.C: 1, Atom.H: 1}): 2,
+            Formula({Atom.C: 1, Atom.H: 2}): 2}))
 
     def test_formula_parse_with_wide_counted_subgroup(self):
         f = Formula.parse('C2(CH)10NO2')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('N'): 1, Atom('O'): 2,
-                                        Formula({Atom('C'): 1, Atom('H'): 1}): 10}))
+        self.assertEqual(f, Formula({
+            Atom.C: 2, Atom.N: 1, Atom.O: 2,
+            Formula({Atom.C: 1, Atom.H: 1}): 10}))
 
     def test_formula_parse_with_radical(self):
         f = Formula.parse('C2H4NO2R')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('H'): 4, Atom('N'): 1,
-                                        Atom('O'): 2, Radical('R'): 1}))
+        self.assertEqual(f, Formula({
+            Atom.C: 2, Atom.H: 4, Atom.N: 1, Atom.O: 2, Radical('R'): 1}))
 
     def test_formula_parse_with_numbered_radical(self):
         f = Formula.parse('C2H4NO2(R1)')
-        self.assertEqual(f, Formula({Atom('C'): 2, Atom('H'): 4, Atom('N'): 1,
-                                        Atom('O'): 2, Radical('R1'): 1}))
+        self.assertEqual(f, Formula({
+            Atom.C: 2, Atom.H: 4, Atom.N: 1, Atom.O: 2, Radical('R1'): 1}))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Creates a metaclass for `Atom` so that standard elements can be accessed as properties on the `Atom` class, e.g. `Atom.H` instead of `Atom('H')`. This is preferred since typos in the element symbol will more easily be caught this way. Non-standard element symbols can still be created using the normal constructor, e.g. `Atom('X')`. In addition, `Atom` instances are cached by symbol so that trying to construct a new instance with an existing symbol will return the cached (singleton) object.