### PR TITLE
cplex: Work around segfault in Cplex library

### DIFF
--- a/psamm/lpsolver/cplex.py
+++ b/psamm/lpsolver/cplex.py
@@ -106,6 +106,7 @@ class Problem(BaseProblem):
         self._non_zero_objective = set()
 
         self._result = None
+        self._solve_count = 0
 
     @property
     def cplex(self):
@@ -265,39 +266,48 @@ class Problem(BaseProblem):
 
     def _reset_problem_type(self):
         """Reset problem type to whatever is appropriate."""
-        integer_count = 0
-        for func in (self._cp.variables.get_num_binary,
-                     self._cp.variables.get_num_integer,
-                     self._cp.variables.get_num_semicontinuous,
-                     self._cp.variables.get_num_semiinteger):
-            integer_count += func()
 
-        integer = integer_count > 0
-        quad_constr = self._cp.quadratic_constraints.get_num() > 0
-        quad_obj = self._cp.objective.get_num_quadratic_variables() > 0
+        # Only need to reset the type after the first solve. This also works
+        # around a bug in Cplex where get_num_binary() is some rare cases
+        # causes a segfault.
+        if self._solve_count > 0:
+            integer_count = 0
+            for func in (self._cp.variables.get_num_binary,
+                         self._cp.variables.get_num_integer,
+                         self._cp.variables.get_num_semicontinuous,
+                         self._cp.variables.get_num_semiinteger):
+                integer_count += func()
 
-        if not integer:
-            if quad_constr:
-                new_type = self._cp.problem_type.QCP
-            elif quad_obj:
-                new_type = self._cp.problem_type.QP
+            integer = integer_count > 0
+            quad_constr = self._cp.quadratic_constraints.get_num() > 0
+            quad_obj = self._cp.objective.get_num_quadratic_variables() > 0
+
+            if not integer:
+                if quad_constr:
+                    new_type = self._cp.problem_type.QCP
+                elif quad_obj:
+                    new_type = self._cp.problem_type.QP
+                else:
+                    new_type = self._cp.problem_type.LP
             else:
-                new_type = self._cp.problem_type.LP
+                if quad_constr:
+                    new_type = self._cp.problem_type.MIQCP
+                elif quad_obj:
+                    new_type = self._cp.problem_type.MIQP
+                else:
+                    new_type = self._cp.problem_type.MILP
+
+            logger.debug('Setting problem type to {}...'.format(
+                self._cp.problem_type[new_type]))
+            self._cp.set_problem_type(new_type)
         else:
-            if quad_constr:
-                new_type = self._cp.problem_type.MIQCP
-            elif quad_obj:
-                new_type = self._cp.problem_type.MIQP
-            else:
-                new_type = self._cp.problem_type.MILP
-
-        logger.debug('Setting problem type to {}...'.format(
-            self._cp.problem_type[new_type]))
-        self._cp.set_problem_type(new_type)
+            logger.debug('Problem type is {}'.format(
+                self._cp.problem_type[self._cp.get_problem_type()]))
 
         # Force QP/MIQP solver to look for global optimum. We set it here only
         # for QP/MIQP problems to avoid the warnings generated for other
         # problem types when this parameter is set.
+        quad_obj = self._cp.objective.get_num_quadratic_variables() > 0
         if quad_obj:
             self._cp.parameters.solutiontarget.set(
                 self._cp.parameters.solutiontarget.values.optimal_global)
@@ -308,6 +318,7 @@ class Problem(BaseProblem):
     def _solve(self):
         self._reset_problem_type()
         self._cp.solve()
+        self._solve_count += 1
         if (self._cp.solution.get_status() ==
                 self._cp.solution.status.abort_user):
             raise KeyboardInterrupt()


### PR DESCRIPTION
Calling `get_num_binary()` on the Cplex instance appears to cause a segfault in some rare cases. We work around this by avoiding the call on the first solve. This may not work around the segfault if the `solve()` method is called multiple times but at least it works for problems that are only solved once.

The problem reset is only needed if a problem is modified after the first solve, so it should be safe to skip the first part of `_reset_problem_type()` if the problem has not been solved before.