### PR TITLE
Gapfill epsilon option

### DIFF
--- a/psamm/commands/gapfill.py
+++ b/psamm/commands/gapfill.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from __future__ import unicode_literals
 
@@ -21,10 +21,8 @@ import logging
 
 from ..command import (Command, MetabolicMixin, SolverCommandMixin,
                        FilePrefixAppendAction)
-
-from ..gapfill import gapfind, gapfill
-
-from psamm.datasource import reaction
+from ..gapfill import gapfind, gapfill, GapFillError
+from ..datasource import reaction
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +61,13 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
             # Run GapFind on model
             logger.info('Searching for blocked compounds...')
             result = gapfind(self._mm, solver=solver, epsilon=epsilon)
-            blocked = set(compound for compound in result
-                          if compound.compartment != extracellular_comp)
+
+            try:
+                blocked = set(compound for compound in result
+                              if compound.compartment != extracellular_comp)
+            except GapFillError as e:
+                self._log_epsilon_and_fail(epsilon, e)
+
             if len(blocked) > 0:
                 logger.info('Blocked compounds')
                 for compound in blocked:
@@ -87,9 +90,12 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
             model_complete.add_all_transport_reactions(extracellular_comp)
 
             logger.info('Searching for reactions to fill gaps')
-            added_reactions, reversed_reactions = gapfill(
-                model_complete, core, blocked, solver=solver,
-                epsilon=epsilon)
+            try:
+                added_reactions, reversed_reactions = gapfill(
+                    model_complete, core, blocked, solver=solver,
+                    epsilon=epsilon)
+            except GapFillError as e:
+                self._log_epsilon_and_fail(epsilon, e)
 
             for rxnid in added_reactions:
                 rx = model_complete.get_reaction(rxnid)
@@ -104,3 +110,9 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
                 print('{}\t{}\t{}'.format(rxnid, 'Reverse', rxt))
         else:
             logger.info('No blocked compounds found')
+
+    def _log_epsilon_and_fail(self, epsilon, exc):
+        msg = ('Finding blocked compounds failed with epsilon set to {}. Try'
+               ' lowering the epsilon value to reduce artifical constraints on'
+               ' the model.'.format(epsilon))
+        self.fail(msg, exc)


### PR DESCRIPTION
Add option on `gapfill` command to adjust epsilon parameter (threshold for considering a flux value zero or non-zero). In the second commit, an error message is added when the GapFind or GapFill procedure fails, explaining to the user that the epsilon parameter can be adjusted as a possible solution to the failure. Currently `CommandError` is used to report the error which, in addition, generates a usage message which is not appropriate for this kind of error. This should be changed when #74 is fixed.