### PR TITLE
Add default_compartment option in model.yaml

### DIFF
--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -206,7 +206,7 @@ class NativeModel(object):
         return self._model.get('biomass', None)
 
     def get_extracellular_compartment(self):
-        """Return the extracellular comparment specified by the model."""
+        """Return the extracellular compartment specified by the model."""
         return self._model.get('extracellular', 'e')
 
     def get_default_compartment(self):


### PR DESCRIPTION
This changes the YAML model parser so that compounds with no compartment specified will be placed in the default compartment. If not specified in `model.yaml` the default compartment will be `c`. This means that a `None` compartment is no longer created if a reaction does not specify a compartment.

Questions:
- Is it ever desirable to have `None` compartments?
- Is is ok to always convert unspecified compartments to the default compartment?
- How does this interact with psamm-import?