### PR TITLE
Command error methods

### DIFF
--- a/psamm/command.py
+++ b/psamm/command.py
@@ -28,6 +28,7 @@ The :func:`.main` function is the entry point of command line interface.
 from __future__ import division, unicode_literals
 
 import os
+import sys
 import argparse
 import logging
 import abc
@@ -90,6 +91,17 @@ class Command(object):
     @abc.abstractmethod
     def run(self):
         """Execute command"""
+
+    def argument_error(self, msg):
+        """Raise error indicating error parsing an argument."""
+        raise CommandError(msg)
+
+    def fail(self, msg, exc=None):
+        """Exit command as a result of a failure."""
+        logger.error(msg)
+        if exc is not None:
+            logger.debug('Command failure caused by exception!', exc_info=exc)
+        sys.exit(1)
 
 
 class MetabolicMixin(object):

--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -21,7 +21,7 @@ import logging
 
 from six import text_type
 
-from ..command import Command, CommandError
+from ..command import Command
 
 try:
     import xlsxwriter
@@ -42,8 +42,7 @@ class ExcelExportCommand(Command):
     def run(self):
         model = self._model
         if xlsxwriter is None:
-            raise CommandError(
-                'Excel export requires the XlsxWriter python module')
+            self.fail('Excel export requires the XlsxWriter python module')
         workbook = xlsxwriter.Workbook(self._args.file)
         reaction_sheet = workbook.add_worksheet(name='Reactions')
 

--- a/psamm/commands/fastgapfill.py
+++ b/psamm/commands/fastgapfill.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 import argparse
 import logging
 
-from ..command import Command, MetabolicMixin, SolverCommandMixin, CommandError
+from ..command import Command, MetabolicMixin, SolverCommandMixin
 from .. import fastcore, fluxanalysis
 from ..fastgapfill import create_extended_model, fastgapfill
 
@@ -105,12 +105,12 @@ class FastGapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
         else:
             maximized_reaction = self._model.get_biomass_reaction()
             if maximized_reaction is None:
-                raise CommandError('The maximized reaction was not specified')
+                self.argument_error(
+                    'The maximized reaction was not specified')
 
         if not self._mm.has_reaction(maximized_reaction):
-            raise CommandError(
-                'The biomass reaction is not a valid model'
-                ' reaction: {}'.format(maximized_reaction))
+            self.fail('The biomass reaction is not a valid model'
+                      ' reaction: {}'.format(maximized_reaction))
 
         logger.info('Flux balance on induced model maximizing {}'.format(
             maximized_reaction))

--- a/psamm/commands/fba.py
+++ b/psamm/commands/fba.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 import time
 import logging
 
-from ..command import SolverCommandMixin, MetabolicMixin, Command, CommandError
+from ..command import SolverCommandMixin, MetabolicMixin, Command
 from .. import fluxanalysis
 
 logger = logging.getLogger(__name__)
@@ -65,11 +65,11 @@ class FluxBalanceCommand(MetabolicMixin, SolverCommandMixin, Command):
         else:
             reaction = self._model.get_biomass_reaction()
             if reaction is None:
-                raise CommandError('The biomass reaction was not specified')
+                self.argument_error('The biomass reaction was not specified')
 
         if not self._mm.has_reaction(reaction):
-            raise CommandError('Specified reaction is not in model: {}'.format(
-                reaction))
+            self.fail(
+                'Specified reaction is not in model: {}'.format(reaction))
 
         logger.info('Using {} as objective'.format(reaction))
 
@@ -84,8 +84,8 @@ class FluxBalanceCommand(MetabolicMixin, SolverCommandMixin, Command):
             logger.info('Loop removal using thermodynamic constraints')
             result = self.run_tfba(reaction)
         else:
-            raise CommandError('Invalid loop constraint mode: {}'.format(
-                loop_removal))
+            self.argument_error(
+                'Invalid loop constraint mode: {}'.format(loop_removal))
 
         optimum = None
         total_reactions = 0

--- a/psamm/commands/fluxcheck.py
+++ b/psamm/commands/fluxcheck.py
@@ -22,7 +22,7 @@ import logging
 from itertools import product
 
 from ..command import (Command, MetabolicMixin, SolverCommandMixin,
-                       ParallelTaskMixin, CommandError)
+                       ParallelTaskMixin)
 from .. import fluxanalysis, fastcore
 
 logger = logging.getLogger(__name__)
@@ -82,10 +82,9 @@ class FluxConsistencyCommand(MetabolicMixin, SolverCommandMixin,
         enable_fastcore = self._args.fastcore
 
         if enable_tfba and enable_fastcore:
-            raise CommandError(
+            self.argument_error(
                 'Using Fastcore with thermodynamic constraints'
                 ' is not supported!')
-
         start_time = time.time()
 
         if enable_fastcore:

--- a/psamm/commands/fluxcoupling.py
+++ b/psamm/commands/fluxcoupling.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 import logging
 
 from ..command import (Command, SolverCommandMixin, MetabolicMixin,
-                       ParallelTaskMixin, CommandError)
+                       ParallelTaskMixin)
 from .. import fluxanalysis, fluxcoupling
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class FluxCouplingCommand(MetabolicMixin, SolverCommandMixin,
 
         max_reaction = self._model.get_biomass_reaction()
         if max_reaction is None:
-            raise CommandError('The biomass reaction was not specified')
+            self.fail('The biomass reaction was not specified')
 
         fba_fluxes = dict(fluxanalysis.flux_balance(
             self._mm, max_reaction, tfba=False, solver=solver))

--- a/psamm/commands/fva.py
+++ b/psamm/commands/fva.py
@@ -22,7 +22,7 @@ import logging
 from itertools import product
 
 from ..command import (Command, SolverCommandMixin, MetabolicMixin,
-                       ParallelTaskMixin, CommandError)
+                       ParallelTaskMixin)
 from ..util import MaybeRelative
 from .. import fluxanalysis
 
@@ -60,11 +60,11 @@ class FluxVariabilityCommand(MetabolicMixin, SolverCommandMixin,
         else:
             reaction = self._model.get_biomass_reaction()
             if reaction is None:
-                raise CommandError('The biomass reaction was not specified')
+                self.argument_error('The biomass reaction was not specified')
 
         if not self._mm.has_reaction(reaction):
-            raise CommandError('Specified reaction is not in model: {}'.format(
-                reaction))
+            self.fail(
+                'Specified reaction is not in model: {}'.format(reaction))
 
         enable_tfba = self._args.tfba
         if enable_tfba:

--- a/psamm/commands/genedelete.py
+++ b/psamm/commands/genedelete.py
@@ -22,7 +22,7 @@ import time
 import logging
 
 from ..command import (Command, MetabolicMixin, SolverCommandMixin,
-                       CommandError, FilePrefixAppendAction)
+                       FilePrefixAppendAction)
 from .. import fluxanalysis
 from ..expression import boolean
 
@@ -48,7 +48,7 @@ class GeneDeletionCommand(MetabolicMixin, SolverCommandMixin, Command):
         else:
             obj_reaction = self._model.get_biomass_reaction()
             if obj_reaction is None:
-                raise CommandError('The biomass reaction was not specified')
+                self.argument_error('The biomass reaction was not specified')
 
         genes = set()
         gene_assoc = {}

--- a/psamm/commands/masscheck.py
+++ b/psamm/commands/masscheck.py
@@ -22,7 +22,7 @@ import logging
 
 from six import iteritems
 
-from ..command import (Command, CommandError, SolverCommandMixin,
+from ..command import (Command, SolverCommandMixin,
                        MetabolicMixin, FilePrefixAppendAction)
 from .. import massconsistency
 from ..reaction import Compound
@@ -87,8 +87,8 @@ class MassConsistencyCommand(MetabolicMixin, SolverCommandMixin, Command):
         elif self._args.type == 'reaction':
             self._check_reactions(known_inconsistent, zeromass, solver)
         else:
-            raise CommandError('Invalid type of check: {}'.format(
-                self._args.type))
+            self.argument_error(
+                'Invalid type of check: {}'.format(self._args.type))
 
     def _check_compounds(self, known_inconsistent, zeromass, solver):
         logger.info('Checking stoichiometric consistency of compounds...')

--- a/psamm/commands/randomsparse.py
+++ b/psamm/commands/randomsparse.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from ..command import Command, MetabolicMixin, SolverCommandMixin, CommandError
+from ..command import Command, MetabolicMixin, SolverCommandMixin
 from .. import fluxanalysis, util
 from .. import randomsparse
 
@@ -61,11 +61,11 @@ class RandomSparseNetworkCommand(MetabolicMixin, SolverCommandMixin, Command):
         else:
             reaction = self._model.get_biomass_reaction()
             if reaction is None:
-                raise CommandError('The biomass reaction was not specified')
+                self.argument_error('The biomass reaction was not specified')
 
         if not self._mm.has_reaction(reaction):
-            raise CommandError('Specified reaction is not in model: {}'.format(
-                reaction))
+            self.fail(
+                'Specified reaction is not in model: {}'.format(reaction))
 
         if not self._args.tfba:
             solver = self._get_solver()

--- a/psamm/commands/robustness.py
+++ b/psamm/commands/robustness.py
@@ -21,7 +21,7 @@ import time
 import logging
 
 from ..command import (Command, MetabolicMixin, SolverCommandMixin,
-                       ParallelTaskMixin, CommandError)
+                       ParallelTaskMixin)
 from .. import fluxanalysis
 
 from six.moves import range
@@ -78,20 +78,20 @@ class RobustnessCommand(MetabolicMixin, SolverCommandMixin,
         else:
             reaction = self._model.get_biomass_reaction()
             if reaction is None:
-                raise CommandError('The biomass reaction was not specified')
+                self.argument_error('The biomass reaction was not specified')
 
         if not self._mm.has_reaction(reaction):
-            raise CommandError('Specified reaction is not in model: {}'.format(
+            self.fail('Specified biomass reaction is not in model: {}'.format(
                 reaction))
 
         varying_reaction = self._args.varying
         if not self._mm.has_reaction(varying_reaction):
-            raise CommandError('Specified reaction is not in model: {}'.format(
+            self.fail('Specified varying reaction is not in model: {}'.format(
                 varying_reaction))
 
         steps = self._args.steps
         if steps <= 0:
-            raise CommandError('Invalid number of steps: {}\n'.format(steps))
+            self.argument_error('Invalid number of steps: {}\n'.format(steps))
 
         loop_removal = self._args.loop_removal
         if loop_removal == 'tfba':
@@ -106,8 +106,8 @@ class RobustnessCommand(MetabolicMixin, SolverCommandMixin,
         elif loop_removal == 'tfba':
             logger.info('Loop removal using thermodynamic constraints')
         else:
-            raise CommandError('Invalid loop constraint mode: {}'.format(
-                loop_removal))
+            self.argument_error(
+                'Invalid loop constraint mode: {}'.format(loop_removal))
 
         p = fluxanalysis.FluxBalanceProblem(self._mm, solver)
         if loop_removal == 'tfba':
@@ -127,7 +127,7 @@ class RobustnessCommand(MetabolicMixin, SolverCommandMixin,
             flux_min = self._args.minimum
 
         if flux_min > flux_max:
-            raise CommandError('Invalid flux range: {}, {}\n'.format(
+            self.argument_error('Invalid flux range: {}, {}\n'.format(
                 flux_min, flux_max))
 
         logger.info('Varying {} in {} steps between {} and {}'.format(

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -27,8 +27,10 @@ import unittest
 
 from six import StringIO, BytesIO
 
-from psamm.command import main, Command, MetabolicMixin, SolverCommandMixin
+from psamm.command import (main, Command, MetabolicMixin, SolverCommandMixin,
+                           CommandError)
 from psamm.lpsolver import generic
+from psamm.datasource.native import NativeModel
 
 
 @contextmanager
@@ -113,6 +115,7 @@ class TestCommandMain(unittest.TestCase):
                   - reaction: rxn_2_\u03c0
                     upper: 100
                 ''')
+        self._model = NativeModel(self._model_dir)
 
     def tearDown(self):
         shutil.rmtree(self._model_dir)
@@ -334,3 +337,13 @@ class TestCommandMain(unittest.TestCase):
         main(MockMetabolicCommand, args=[
             '--model', self._model_dir])
         self.assertTrue(MockMetabolicCommand.has_metabolic_model)
+
+    def test_command_fail(self):
+        mock_command = MockCommand(self._model, None)
+        with self.assertRaises(SystemExit):
+            mock_command.fail('Run time error')
+
+    def test_command_argument_error(self):
+        mock_command = MockCommand(self._model, None)
+        with self.assertRaises(CommandError):
+            mock_command.argument_error(msg='Argument error')


### PR DESCRIPTION
I am not sure if providing a string to the function `fail()` is OK, but it seems like that if it is a True value, and it is not a tuple, python would call sys.exc_info() to get the exception info.

Also, I don't know how to test the `argument_error()` and `fail()` using the existing structure in `test_command.py`, I want to construct a Command instance, but it's an abstract base class. To test these two functions, I don't want to run any actual command either.