### PR TITLE
sbml: writer now uses NativeModel instead of MetabolicModel

### DIFF
--- a/psamm/commands/sbmlexport.py
+++ b/psamm/commands/sbmlexport.py
@@ -26,6 +26,4 @@ class SBMLExport(MetabolicMixin, Command):
 
     def run(self):
         writer = sbml.SBMLWriter()
-        writer.write_model(
-            sys.stdout, self._mm, self._model.parse_reactions(),
-            self._model.parse_compounds())
+        writer.write_model(sys.stdout, self._model)


### PR DESCRIPTION
It's hard to take a look at the differences in the output, as they are grouped in just one line. I think there are something could be changed: 1) reaction id generated by the writer() to each reaction; 2) the flux limit for each reaction, as in NativeModel, the direction of each reaction could be forward, reverse or both, I assume using MetabolicModel would only generates forward and both; 3) I use 1000.0 and 0.0 and the default_flux_limit and default_flux_limit_blocked, so it may not be integer 1000 and 0 in some cases.

The difficult part lies in the flux limit part.