### PR TITLE
Default flux limit

### DIFF
--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -85,8 +85,6 @@ class ExcelExportCommand(Command):
         media_sheet.write_string(0, 3, 'Upper Limit')
 
         default_flux = model.get_default_flux_limit()
-        if default_flux is None:
-            default_flux = 1000
 
         for x, (compound, reaction, lower, upper) in enumerate(
                 model.parse_medium()):

--- a/psamm/commands/tableexport.py
+++ b/psamm/commands/tableexport.py
@@ -90,8 +90,6 @@ class ExportTableCommand(Command):
         print('{}\t{}\t{}\t{}'.format('Compound ID', 'Reaction ID',
                                       'Lower Limit', 'Upper Limit'))
         default_flux = self._model.get_default_flux_limit()
-        if default_flux is None:
-            default_flux = 1000
 
         for compound, reaction, lower, upper in self._model.parse_medium():
             if lower is None:

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -211,7 +211,7 @@ class NativeModel(object):
 
     def get_default_flux_limit(self):
         """Return the default flux limit specified by the model"""
-        return self._model.get('default_flux_limit', None)
+        return self._model.get('default_flux_limit', 1000)
 
     def parse_reactions(self):
         """Yield tuples of reaction ID and reactions defined in the model"""

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -316,7 +316,7 @@ class TestCommandMain(unittest.TestCase):
         self.assertEqual(f.getvalue(), '\n'.join([
             'Model Name: Test model',
             'Biomass Reaction: rxn_1',
-            'Default Flux Limits: None',
+            'Default Flux Limits: 1000',
             ''
         ]))
 


### PR DESCRIPTION
`NativeModel.get_default_flux_limit()` returns 1000 instead of `None` if no default value found in the model definition. Also change two commands and test cases related to this change.