### PR TITLE
database: Retain compound order

### DIFF
--- a/psamm/database.py
+++ b/psamm/database.py
@@ -18,7 +18,7 @@
 """Representation of metabolic network databases."""
 
 import abc
-from collections import defaultdict, Mapping
+from collections import defaultdict, OrderedDict, Mapping
 
 from six import iteritems, add_metaclass
 
@@ -164,7 +164,7 @@ class DictDatabase(MetabolicDatabase):
 
     def __init__(self):
         super(DictDatabase, self).__init__()
-        self._reactions = defaultdict(dict)
+        self._reactions = OrderedDict()
         self._compound_reactions = defaultdict(set)
         self._reversible = set()
 
@@ -215,6 +215,7 @@ class DictDatabase(MetabolicDatabase):
             self._reversible.discard(reaction_id)
             del self._reactions[reaction_id]
 
+        self._reactions[reaction_id] = OrderedDict()
         # Add values to global (sparse) stoichiometric matrix
         # Compounds that occur on both sides will get a stoichiometric
         # value based on the sum of the signed values on each side.


### PR DESCRIPTION
Based on first commit in #108. Extended tests to check that ordering is preserved. @spikeliu can you tell me if this looks good?