### PR TITLE
lp: Add variable namespaces

### DIFF
--- a/psamm/fluxanalysis.py
+++ b/psamm/fluxanalysis.py
@@ -71,6 +71,9 @@ class FluxBalanceProblem(object):
         self._prob = solver.create_problem()
         self._model = model
 
+        self._z = None
+        self._v = v = self._prob.namespace()
+
         self._has_minimization_vars = False
 
         # We keep track of temporary constraints from the last optimization so
@@ -83,13 +86,13 @@ class FluxBalanceProblem(object):
         # Define flux variables
         for reaction_id in self._model.reactions:
             lower, upper = self._model.limits[reaction_id]
-            self._prob.define(('v', reaction_id), lower=lower, upper=upper)
+            v.define([reaction_id], lower=lower, upper=upper)
 
         # Define constraints
         massbalance_lhs = {compound: 0 for compound in model.compounds}
         for spec, value in iteritems(self._model.matrix):
             compound, reaction_id = spec
-            massbalance_lhs[compound] += self.get_flux_var(reaction_id) * value
+            massbalance_lhs[compound] += v(reaction_id) * value
         for compound, lhs in iteritems(massbalance_lhs):
             self._prob.add_linear_constraints(lhs == 0)
 
@@ -122,43 +125,47 @@ class FluxBalanceProblem(object):
         model is not unusually large.
         """
 
-        p = self._prob
+        internal = set(r for r in self._model.reactions
+                       if not self._model.is_exchange(r))
+
+        # Reaction fluxes
+        v = self._v
+
+        # Indicator variable
+        alpha = self._prob.namespace(internal, types=lp.VariableType.Binary)
+
+        # Delta mu is the stoichiometrically weighted sum of the compound mus.
+        dmu = self._prob.namespace(internal)
+
         for reaction_id in self._model.reactions:
             if not self._model.is_exchange(reaction_id):
-                # Indicator variable
-                p.define(('alpha', reaction_id), types=lp.VariableType.Binary)
-
-                # Delta mu is the stoichiometrically weighted sum of the
-                # compound mus.
-                p.define(('dmu', reaction_id))
-
-                flux = self.get_flux_var(reaction_id)
-                alpha = p.var(('alpha', reaction_id))
-                dmu = p.var(('dmu', reaction_id))
+                flux = v(reaction_id)
+                alpha_r = alpha(reaction_id)
+                dmu_r = dmu(reaction_id)
 
                 lower, upper = self._model.limits[reaction_id]
 
                 # Constrain the reaction to a direction determined by alpha
                 # and contrain the delta mu to a value in [-em; -1] if
                 # alpha is one, otherwise in [1; em].
-                p.add_linear_constraints(
-                    flux >= lower * (1 - alpha),
-                    flux <= upper * alpha,
-                    dmu >= -em * alpha + (1 - alpha),
-                    dmu <= em * (1 - alpha) - alpha)
+                self._prob.add_linear_constraints(
+                    flux >= lower * (1 - alpha_r),
+                    flux <= upper * alpha_r,
+                    dmu_r >= -em * alpha_r + (1 - alpha_r),
+                    dmu_r <= em * (1 - alpha_r) - alpha_r)
 
         # Define mu variables
-        p.define(*(('mu', compound) for compound in self._model.compounds))
+        mu = self._prob.namespace(self._model.compounds)
 
         tdbalance_lhs = {reaction_id: 0
                          for reaction_id in self._model.reactions}
         for spec, value in iteritems(self._model.matrix):
             compound, reaction_id = spec
             if not self._model.is_exchange(reaction_id):
-                tdbalance_lhs[reaction_id] += p.var(('mu', compound)) * value
+                tdbalance_lhs[reaction_id] += mu(compound) * value
         for reaction_id, lhs in iteritems(tdbalance_lhs):
             if not self._model.is_exchange(reaction_id):
-                p.add_linear_constraints(lhs == p.var(('dmu', reaction_id)))
+                self._prob.add_linear_constraints(lhs == dmu(reaction_id))
 
     def maximize(self, reaction):
         """Solve the model by maximizing the given reaction.
@@ -189,19 +196,14 @@ class FluxBalanceProblem(object):
 
     def _add_minimization_vars(self):
         """Add variables and constraints for L1 norm minimization."""
-        if self._has_minimization_vars:
-            return
 
-        var_names = (('z', reaction_id)
-                     for reaction_id in self._model.reactions)
-        self._prob.define(*var_names, lower=0)
+        self._z = self._prob.namespace(self._model.reactions, lower=0)
 
         # Define constraints
-        v = self._prob.set(('v', rxnid) for rxnid in self._model.reactions)
-        z = self._prob.set(('z', rxnid) for rxnid in self._model.reactions)
-        self._prob.add_linear_constraints(z >= v, v >= -z)
+        v = self._v.set(self._model.reactions)
+        z = self._z.set(self._model.reactions)
 
-        self._has_minimization_vars = True
+        self._prob.add_linear_constraints(z >= v, v >= -z)
 
     def minimize_l1(self, weights={}):
         """Solve the model by minimizing the L1 norm of the fluxes.
@@ -211,11 +213,12 @@ class FluxBalanceProblem(object):
         (default 1).
         """
 
-        self._add_minimization_vars()
+        if self._z is None:
+            self._add_minimization_vars()
 
-        objective = self._prob.expr({
-            ('z', reaction_id): -weights.get(reaction_id, 1)
-            for reaction_id in self._model.reactions})
+        objective = self._z.expr(
+            (reaction_id, -weights.get(reaction_id, 1))
+            for reaction_id in self._model.reactions)
         self._prob.set_objective(objective)
 
         self._solve()
@@ -266,18 +269,17 @@ class FluxBalanceProblem(object):
 
     def get_flux_var(self, reaction):
         """Get LP variable representing the reaction flux."""
-        return self._prob.var(('v', reaction))
+        return self._v(reaction)
 
     def flux_expr(self, reaction):
         """Get LP expression representing the reaction flux."""
         if isinstance(reaction, dict):
-            return self._prob.expr(
-                {('v', r): v for r, v in iteritems(reaction)})
-        return self._prob.expr(('v', reaction))
+            return self._v.expr(iteritems(reaction))
+        return self._v(reaction)
 
     def get_flux(self, reaction):
         """Get resulting flux value for reaction."""
-        return self._prob.result.get_value(('v', reaction))
+        return self._prob.result.get_value(self._v(reaction))
 
 
 def flux_balance(model, reaction, tfba, solver):

--- a/psamm/gapfill.py
+++ b/psamm/gapfill.py
@@ -47,44 +47,42 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
     prob = solver.create_problem()
 
     # Define flux variables
+    v = prob.namespace()
     for reaction_id in model.reactions:
         lower, upper = model.limits[reaction_id]
-        prob.define(('v', reaction_id), lower=lower, upper=upper)
+        v.define([reaction_id], lower=lower, upper=upper)
 
     # Define constraints on production of metabolites in reaction
+    w = prob.namespace(types=lp.VariableType.Binary)
     binary_cons_lhs = {compound: 0 for compound in model.compounds}
     for spec, value in iteritems(model.matrix):
         compound, reaction_id = spec
         if value != 0 and (reaction_id in model.reversible or value > 0):
-            prob.define(('w', reaction_id, compound),
-                        types=lp.VariableType.Binary)
+            w.define([spec])
+            w_var = w(spec)
+            sv = v(reaction_id) * float(value)
 
-            w = prob.var(('w', reaction_id, compound))
-            sv = float(value) * prob.var(('v', reaction_id))
-
-            prob.add_linear_constraints(sv <= v_max*w)
+            prob.add_linear_constraints(sv <= v_max * w_var)
             if model.is_reversible(reaction_id):
-                prob.add_linear_constraints(sv >= epsilon-v_max*(1 - w))
+                prob.add_linear_constraints(
+                    sv >= epsilon - v_max * (1 - w_var))
             else:
-                prob.add_linear_constraints(sv >= epsilon*w)
+                prob.add_linear_constraints(sv >= epsilon * w_var)
 
-            binary_cons_lhs[compound] += w
+            binary_cons_lhs[compound] += w_var
 
-    prob.define(*(('xp', compound) for compound in model.compounds),
-                types=lp.VariableType.Binary)
-
-    objective = prob.expr(
-        {('xp', compound): 1 for compound in model.compounds})
+    xp = prob.namespace(model.compounds, types=lp.VariableType.Binary)
+    objective = xp.sum(model.compounds)
     prob.set_objective(objective)
 
     for compound, lhs in iteritems(binary_cons_lhs):
-        prob.add_linear_constraints(lhs >= prob.var(('xp', compound)))
+        prob.add_linear_constraints(lhs >= xp(compound))
 
     # Define mass balance constraints
     massbalance_lhs = {compound: 0 for compound in model.compounds}
     for spec, value in iteritems(model.matrix):
         compound, reaction_id = spec
-        massbalance_lhs[compound] += prob.var(('v', reaction_id)) * value
+        massbalance_lhs[compound] += v(reaction_id) * value
     for compound, lhs in iteritems(massbalance_lhs):
         # The constraint is merely >0 meaning that we have implicit sinks
         # for all compounds.
@@ -96,7 +94,7 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
         raise GapFillError('Non-optimal solution: {}'.format(result.status))
 
     for compound in model.compounds:
-        if result.get_value(('xp', compound)) == 0:
+        if result.get_value(xp(compound)) == 0:
             yield compound
 
 
@@ -124,65 +122,54 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
     prob = solver.create_problem()
 
     # Define flux variables
-    prob.define(*(('v', reaction_id) for reaction_id in model.reactions),
-                lower=-v_max, upper=v_max)
+    v = prob.namespace(model.reactions, lower=-v_max, upper=v_max)
 
     # Add binary indicator variables
     database_reactions = set(model.reactions).difference(core)
-    prob.define(*(('ym', reaction_id) for reaction_id in core),
-                types=lp.VariableType.Binary)
-    prob.define(*(('yd', reaction_id) for reaction_id in database_reactions),
-                types=lp.VariableType.Binary)
+    ym = prob.namespace(core, types=lp.VariableType.Binary)
+    yd = prob.namespace(database_reactions, types=lp.VariableType.Binary)
 
-    objective = prob.expr(
-        {('ym', reaction_id): 1 for reaction_id in core})
-    objective += prob.expr(
-        {('yd', reaction_id): 1 for reaction_id in database_reactions})
+    objective = ym.sum(core) + yd.sum(database_reactions)
     prob.set_objective(objective)
 
     # Add constraints on core reactions
-    for reaction_id in core:
-        v = prob.var(('v', reaction_id))
-        if model.is_reversible(reaction_id):
-            prob.add_linear_constraints(v >= model.limits[reaction_id].lower)
+    for r in core:
+        if model.is_reversible(r):
+            prob.add_linear_constraints(v(r) >= model.limits[r].lower)
         else:
-            ym = prob.var(('ym', reaction_id))
-            prob.add_linear_constraints(v >= -v_max * ym)
-        prob.add_linear_constraints(v <= model.limits[reaction_id].upper)
+            prob.add_linear_constraints(v(r) >= -v_max * ym(r))
+        prob.add_linear_constraints(v(r) <= model.limits[r].upper)
 
     # Add constraints on database reactions
-    for reaction_id in database_reactions:
-        v = prob.var(('v', reaction_id))
-        yd = prob.var(('yd', reaction_id))
-        prob.add_linear_constraints(
-            v >= yd * model.limits[reaction_id].lower,
-            v <= yd * model.limits[reaction_id].upper)
+    for r in database_reactions:
+        prob.add_linear_constraints(v(r) >= yd(r) * model.limits[r].lower)
+        prob.add_linear_constraints(v(r) <= yd(r) * model.limits[r].upper)
 
     # Define constraints on production of blocked metabolites in reaction
+    w = prob.namespace(types=lp.VariableType.Binary)
+    yn = prob.namespace(types=lp.VariableType.Binary)
     binary_cons_lhs = {compound: 0 for compound in blocked}
     for (compound, reaction_id), value in iteritems(model.matrix):
         if compound in blocked and value != 0:
-            prob.define(('w', reaction_id, compound),
-                        types=lp.VariableType.Binary)
+            w.define([(compound, reaction_id)])
+            w_var = w((compound, reaction_id))
 
-            w = prob.var(('w', reaction_id, compound))
-            sv = float(value) * prob.var(('v', reaction_id))
+            sv = float(value) * v(reaction_id)
+            prob.add_linear_constraints(
+                sv >= epsilon - v_max * (1 - w_var))
+            prob.add_linear_constraints(sv <= v_max * w_var)
 
-            prob.add_linear_constraints(sv >= epsilon - v_max * (1 - w))
-            prob.add_linear_constraints(sv <= v_max * w)
-
-            if model.is_reversible(reaction_id) or value > 0:
-                binary_cons_lhs[compound] += w
+            if reaction_id in model.reversible or value > 0:
+                binary_cons_lhs[compound] += w_var
             elif reaction_id in core:
                 # In this case, we need to perform a logical AND on the w and
                 # ym variables. This is done by introducing another helper
                 # variable, yn.
-                prob.define(('yn', reaction_id, compound),
-                            types=lp.VariableType.Binary)
-                yn = prob.var(('yn', reaction_id, compound))
+                yn.define([(reaction_id, compound)])
+                yn_var = yn((reaction_id, compound))
                 prob.add_linear_constraints(
-                    2 * yn <= w + prob.var(('ym', reaction_id)))
-                binary_cons_lhs[compound] += yn
+                    2 * yn_var <= w_var + ym(reaction_id))
+                binary_cons_lhs[compound] += yn_var
 
     for compound, lhs in iteritems(binary_cons_lhs):
         if compound in blocked:
@@ -190,9 +177,8 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
 
     # Define mass balance constraints
     massbalance_lhs = {compound: 0 for compound in model.compounds}
-    for spec, value in iteritems(model.matrix):
-        compound, reaction_id = spec
-        massbalance_lhs[compound] += prob.var(('v', reaction_id)) * value
+    for (compound, reaction_id), value in iteritems(model.matrix):
+        massbalance_lhs[compound] += v(reaction_id) * value
     for compound, lhs in iteritems(massbalance_lhs):
         # The constraint is merely >0 meaning that we have implicit sinks
         # for all compounds.
@@ -205,12 +191,12 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
 
     def added_iter():
         for reaction_id in database_reactions:
-            if result.get_value(('yd', reaction_id)) > 0.5:
+            if yd.value(reaction_id) > 0.5:
                 yield reaction_id
 
     def reversed_iter():
         for reaction_id in core:
-            if result.get_value(('ym', reaction_id)) > 0.5:
+            if ym.value(reaction_id) > 0.5:
                 yield reaction_id
 
     return added_iter(), reversed_iter()


### PR DESCRIPTION
This removes the need for using magic strings to identify a subset of variables. Improves the ability to provide abstractions on LP problems without the risk of namespace collisions.