### PR TITLE
boolean: Provide access to root of term tree

### DIFF
--- a/psamm/datasource/sbml.py
+++ b/psamm/datasource/sbml.py
@@ -731,7 +731,7 @@ class SBMLWriter(object):
                     And(*(Variable(i) for i in r_genes[r_id])))
             else:
                 e = Expression(r_genes[r_id])
-            gene_stack = [(e._root, genes)]
+            gene_stack = [(e.root, genes)]
             while len(gene_stack) > 0:
                 current, parent = gene_stack.pop()
                 if isinstance(current, Or):

--- a/psamm/expression/boolean.py
+++ b/psamm/expression/boolean.py
@@ -140,6 +140,11 @@ class Expression(object):
             self._variables = FrozenOrderedSet(_vars)
 
     @property
+    def root(self):
+        """Return root term, variable or boolean of the expression."""
+        return self._root
+
+    @property
     def variables(self):
         """Immutable set of variables in the expression."""
         return self._variables

--- a/psamm/tests/test_boolean_expression.py
+++ b/psamm/tests/test_boolean_expression.py
@@ -131,6 +131,15 @@ class TestExpression(unittest.TestCase):
             Variable('b1'), Variable('b2'), Variable('b3'), Variable('b4')
         ])
 
+    def test_expression_root(self):
+        e = Expression(Or(Variable('b1'), Variable('b2')))
+        root = e.root
+        self.assertIsInstance(e.root, Or)
+
+    def test_expression_root_boolean(self):
+        e = Expression(False)
+        self.assertEqual(e.root, False)
+
     def test_expression_to_string(self):
         e = Expression('(a and b) or (c and d)')
         self.assertEqual(str(e), '(a and b) or (c and d)')


### PR DESCRIPTION
Provides access to the root term (`And`, `Or`, `Variable` or `bool`) of the boolean expression. Previously the private `_root` member of `Expression` was accessed when writing SBML files because there was no public interface for obtaining this.