### PR TITLE
gapfill: Fix check for blocked compounds

### DIFF
--- a/psamm/gapfill.py
+++ b/psamm/gapfill.py
@@ -94,7 +94,7 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
         raise GapFillError('Non-optimal solution: {}'.format(result.status))
 
     for compound in model.compounds:
-        if result.get_value(xp(compound)) == 0:
+        if result.get_value(xp(compound)) < 0.5:
             yield compound
 
 


### PR DESCRIPTION
Fixes a possible problem in `gapfind` when the solver result is not exactly zero.