### PR TITLE
Activate GLPK MILP support

### DIFF
--- a/psamm/lpsolver/generic.py
+++ b/psamm/lpsolver/generic.py
@@ -80,7 +80,7 @@ try:
     _solvers.append({
         'class': glpk.Solver,
         'name': 'glpk',
-        'integer': False,
+        'integer': True,
         'quadratic': False,
         'rational': False,
         'priority': 8

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -37,9 +37,16 @@ from .lp import (Expression, RelationSense, ObjectiveSense, VariableType,
 # Module-level logging
 logger = logging.getLogger(__name__)
 
-# Disable terminal output. TODO instead the output should be redirected to
-# the Python logger.
-swiglpk.glp_term_out(0)
+# Logger specific to log messages from GLPK library
+_glpk_logger = logging.getLogger('glpk')
+
+
+# Redirect GLPK terminal output to logger
+def _term_hook(s):
+    _glpk_logger.debug(s.rstrip())
+
+swiglpk.glp_term_hook(_term_hook)
+
 
 _INF = float('inf')
 

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -51,6 +51,10 @@ class GLPKError(Exception):
 class Solver(BaseSolver):
     """Represents an LP-solver using Gurobi."""
 
+    def __init__(self):
+        super(Solver, self).__init__()
+        logger.warn('Support for GLPK solver is experimental!')
+
     def create_problem(self, **kwargs):
         """Create a new LP-problem using the solver."""
         return Problem(**kwargs)

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -260,9 +260,6 @@ class Problem(BaseProblem):
         if sense is not None:
             self.set_objective_sense(sense)
 
-        logger.debug('Scaling problem using glp_scale_prob()')
-        swiglpk.glp_scale_prob(self._p, swiglpk.GLP_SF_AUTO)
-
         parm = swiglpk.glp_smcp()
         swiglpk.glp_init_smcp(parm)
         if self._do_presolve:

--- a/psamm/tests/test_gapfill.py
+++ b/psamm/tests/test_gapfill.py
@@ -43,14 +43,15 @@ class TestGapfind(unittest.TestCase):
 
     def test_gapfind(self):
         self.model.remove_reaction('rxn_4')
-        compounds = set(gapfind(self.model, self.solver))
+        compounds = set(gapfind(self.model, self.solver, epsilon=0.1))
         self.assertEqual(compounds, {Compound('D'), Compound('E')})
 
     def test_gapfill_add_reaction(self):
         core = set(self.model.reactions) - {'rxn_4'}
         blocked = {Compound('D'), Compound('E')}
 
-        add, rev = gapfill(self.model, core, blocked, self.solver)
+        add, rev = gapfill(
+            self.model, core, blocked, self.solver, epsilon=0.1)
         self.assertEqual(set(rev), set())
         self.assertEqual(set(add), {'rxn_4'})
 
@@ -59,6 +60,7 @@ class TestGapfind(unittest.TestCase):
         core = set(self.model.reactions)
         blocked = {Compound('D'), Compound('E')}
 
-        add, rev = gapfill(self.model, core, blocked, self.solver)
+        add, rev = gapfill(
+            self.model, core, blocked, self.solver, epsilon=0.1)
         self.assertEqual(set(rev), {'rxn_4'})
         self.assertEqual(set(add), set())


### PR DESCRIPTION
GLPK is marked as having integer (MILP) support in the generic interface.

Also changes the test cases for GapFind/GapFill to work with GLPK. GLPK is not able to handle a wide range between the epsilon and big-M parameter so epsilon was increased for this test.