### PR TITLE
formulabalance: Fix exclude reactions

### DIFF
--- a/psamm/commands/formulacheck.py
+++ b/psamm/commands/formulacheck.py
@@ -52,7 +52,7 @@ class FormulaBalanceCommand(Command):
         for reaction, result in formula_balance(self._model):
             count += 1
 
-            if reaction in exclude or reaction.equation is None:
+            if reaction.id in exclude or reaction.equation is None:
                 continue
 
             if result is None:


### PR DESCRIPTION
Fixes a bug where the `formulabalance` command did not correctly check against the set of excluded reactions.