### PR TITLE
WIP: Argparse reaction reference

### DIFF
--- a/psamm/command.py
+++ b/psamm/command.py
@@ -212,6 +212,17 @@ class FilePrefixAppendAction(argparse.Action):
             arguments.append(values)
 
 
+class ReactionReference(object):
+    def __init__(self, reaction_ref):
+        self._reaction_id = reaction_ref
+
+    def resolve(self, model):
+        if not model.has_reaction(self._reaction_id):
+            raise ValueError('Invalid reaction reference')
+
+        return self._reaction_id
+
+
 class _ErrorMarker(object):
     """Signals error in the child process."""
 

--- a/psamm/commands/formulacheck.py
+++ b/psamm/commands/formulacheck.py
@@ -19,7 +19,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from ..command import Command, FilePrefixAppendAction
+from ..command import Command, FilePrefixAppendAction, ReactionReference
 from ..formula import Formula
 from ..balancecheck import formula_balance
 
@@ -38,14 +38,17 @@ class FormulaBalanceCommand(Command):
     def init_parser(cls, parser):
         parser.add_argument(
             '--exclude', metavar='reaction', action=FilePrefixAppendAction,
-            type=str, default=[], help='Exclude reaction from balance check')
+            type=ReactionReference, default=[],
+            help='Exclude reaction from balance check')
         super(FormulaBalanceCommand, cls).init_parser(parser)
 
     def run(self):
         """Run formula balance command"""
 
+        mm = self._model.create_metabolic_model()
+
         # Create a set of excluded reactions
-        exclude = set(self._args.exclude)
+        exclude = set(r.resolve(mm) for r in self._args.exclude)
         count = 0
         unbalanced = 0
         unchecked = 0


### PR DESCRIPTION
Add specialized `argparse` type for reaction references. This type guards against using non-existing ID since the actual ID string can only be obtained (through `resolve()`) if the reaction is defined in the model. Currently requires a `MetabolicModel` which is not ideal for commands that otherwise don't require this model representation. This may have to wait for the work on restructuring `NativeModel` to be implemented in terms of that model representation instead.