### PR TITLE
Objective mixin

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -75,14 +75,14 @@ or with a specific reaction:
 
 .. code-block:: shell
 
-    $ psamm-model fba ATPM
+    $ psamm-model fba --objective=ATPM
 
 By default, this performs a standard FBA and the result is output as
 tab-separated values with the reaction ID, the reaction flux and the reaction
 equation. If the parameter ``--loop-removal`` is given, the flux of the
 internal reactions is further constrained to remove internal loops
 [Schilling00]_. Loop removal is more time-consuming and under normal
-cicumstances the biomass reaction flux will *not* change in response to the
+circumstances the biomass reaction flux will *not* change in response to the
 loop removal (only internal reaction fluxes may change). The ``--loop-removal``
 option is followed by ``none`` (no loop removal), ``tfba`` (removal using
 thermodynamic constraints), or ``l1min`` (L1 minimization of the fluxes). For
@@ -98,7 +98,7 @@ Flux variability analysis (``fva``)
 This command will find the possible flux range of each reaction when the
 biomass is at the maximum value [Mahadevan03]_. The command will use the
 biomass reaction specified in the model definition, or alternatively, a
-reaction can be given on the command line.
+reaction can be given on the command line following the ``--objective`` option.
 
 .. code-block:: shell
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -832,13 +832,13 @@ different conditions.
 By default, PSAMM fba will use the biomass function designated in the central
 model file as the objective function. If the biomass tag is not defined in a
 ``model.yaml`` file or if you want to use a different reaction as the
-objective function, you can simply specify what the reaction ID is at the
-end of the command. For example to maximize the citrate synthase reactions,
-CS, the command would be as follows:
+objective function, you can simply specify it using the ``--objective`` option.
+For example to maximize the citrate synthase reactions, `CS`, the command would
+be as follows:
 
 .. code-block:: shell
 
-    (psamm-env) $ psamm-model fba CS
+    (psamm-env) $ psamm-model fba --objective=CS
 
 Flux balance analysis will be used throughout this tutorial as both a checking
 tool during model curation and an analysis tool. PSAMM allows you to easily
@@ -1102,7 +1102,7 @@ the `FRUKIN` reaction is maximized the following command can be used:
 
 .. code-block:: shell
 
-    (psamm-env) $ psamm-model fba FRUKIN --all-reactions
+    (psamm-env) $ psamm-model fba --objective=FRUKIN --all-reactions
 
 It can be seen from this simulation that the `FRUKIN` reaction is now being
 used and that the fluxes through the network have changed from when the biomass

--- a/psamm/command.py
+++ b/psamm/command.py
@@ -113,6 +113,31 @@ class MetabolicMixin(object):
         self._mm = self._model.create_metabolic_model()
 
 
+class ObjectiveMixin(object):
+    """Mixin for commands that use biomass as objective.
+
+    Allows the user to override the default objective from the command line.
+    """
+
+    @classmethod
+    def init_parser(cls, parser):
+        parser.add_argument('--objective', help='Reaction to use as objective')
+        super(ObjectiveMixin, cls).init_parser(parser)
+
+    def _get_objective(self, log=True):
+        if self._args.objective is not None:
+            reaction = self._args.objective
+        else:
+            reaction = self._model.get_biomass_reaction()
+            if reaction is None:
+                self.argument_error('The objective reaction was not specified')
+
+        if log:
+            logger.info('Using {} as objective'.format(reaction))
+
+        return reaction
+
+
 class LoopRemovalMixin(object):
     """Mixin for commands that perform loop removal."""
 

--- a/psamm/commands/randomsparse.py
+++ b/psamm/commands/randomsparse.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 import logging
 
 from ..command import (Command, MetabolicMixin, LoopRemovalMixin,
-                       SolverCommandMixin)
+                       ObjectiveMixin, SolverCommandMixin)
 from .. import fluxanalysis, util
 from .. import randomsparse
 
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class RandomSparseNetworkCommand(MetabolicMixin, LoopRemovalMixin,
-                                 SolverCommandMixin, Command):
+                                 ObjectiveMixin, SolverCommandMixin, Command):
     """Find a random minimal network of model reactions.
 
     Given a reaction to optimize and a threshold, delete reactions randomly
@@ -46,7 +46,6 @@ class RandomSparseNetworkCommand(MetabolicMixin, LoopRemovalMixin,
 
     @classmethod
     def init_parser(cls, parser):
-        parser.add_argument('--objective', help='Reaction flux to maximize')
         parser.add_argument(
             'threshold', help='Threshold of max reaction flux',
             type=util.MaybeRelative)
@@ -57,13 +56,7 @@ class RandomSparseNetworkCommand(MetabolicMixin, LoopRemovalMixin,
         super(RandomSparseNetworkCommand, cls).init_parser(parser)
 
     def run(self):
-        if self._args.objective is not None:
-            reaction = self._args.objective
-        else:
-            reaction = self._model.get_biomass_reaction()
-            if reaction is None:
-                self.argument_error('The biomass reaction was not specified')
-
+        reaction = self._get_objective()
         if not self._mm.has_reaction(reaction):
             self.fail(
                 'Specified reaction is not in model: {}'.format(reaction))

--- a/psamm/commands/robustness.py
+++ b/psamm/commands/robustness.py
@@ -21,7 +21,7 @@ import time
 import logging
 
 from ..command import (Command, MetabolicMixin, LoopRemovalMixin,
-                       SolverCommandMixin, ParallelTaskMixin)
+                       ObjectiveMixin, SolverCommandMixin, ParallelTaskMixin)
 from .. import fluxanalysis
 
 from six.moves import range
@@ -29,8 +29,8 @@ from six.moves import range
 logger = logging.getLogger(__name__)
 
 
-class RobustnessCommand(MetabolicMixin, LoopRemovalMixin, SolverCommandMixin,
-                        ParallelTaskMixin, Command):
+class RobustnessCommand(MetabolicMixin, LoopRemovalMixin, ObjectiveMixin,
+                        SolverCommandMixin, ParallelTaskMixin, Command):
     """Run robustness analysis on the model.
 
     Given a reaction to maximize and a reaction to vary,
@@ -53,7 +53,6 @@ class RobustnessCommand(MetabolicMixin, LoopRemovalMixin, SolverCommandMixin,
         parser.add_argument(
             '--maximum', metavar='V', type=float,
             help='Maximum flux value of varying reacton')
-        parser.add_argument('--objective', help='Reaction to maximize')
         parser.add_argument(
             '--all-reaction-fluxes',
             help='Print reaction flux for all model reactions',
@@ -72,13 +71,7 @@ class RobustnessCommand(MetabolicMixin, LoopRemovalMixin, SolverCommandMixin,
             elif compound.id not in compound_name:
                 compound_name[compound.id] = compound.id
 
-        if self._args.objective is not None:
-            reaction = self._args.objective
-        else:
-            reaction = self._model.get_biomass_reaction()
-            if reaction is None:
-                self.argument_error('The biomass reaction was not specified')
-
+        reaction = self._get_objective()
         if not self._mm.has_reaction(reaction):
             self.fail('Specified biomass reaction is not in model: {}'.format(
                 reaction))


### PR DESCRIPTION
Add `ObjectiveMixin` for `Command`. Adds standardized option to override the biomass reaction as the objective. Changes a few commands to use `--objective` as option instead of a positional argument.