### PR TITLE
gapfill: Reformulate GapFind/GapFill

### DIFF
--- a/psamm/commands/gapfill.py
+++ b/psamm/commands/gapfill.py
@@ -84,6 +84,8 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
                         for c in sorted(blocked))))
 
         if len(blocked) > 0:
+            exclude = {self._model.get_biomass_reaction()}
+
             # Add exchange and transport reactions to database
             model_complete = self._mm.copy()
             logger.info('Adding database, exchange and transport reactions')
@@ -94,7 +96,7 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
             logger.info('Searching for reactions to fill gaps')
             try:
                 added_reactions, no_bounds_reactions = gapfill(
-                    model_complete, core, blocked, solver=solver,
+                    model_complete, core, blocked, exclude, solver=solver,
                     epsilon=epsilon, v_max=v_max)
             except GapFillError as e:
                 self._log_epsilon_and_fail(epsilon, e)

--- a/psamm/commands/gapfill.py
+++ b/psamm/commands/gapfill.py
@@ -93,7 +93,7 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
 
             logger.info('Searching for reactions to fill gaps')
             try:
-                added_reactions, reversed_reactions = gapfill(
+                added_reactions, no_bounds_reactions = gapfill(
                     model_complete, core, blocked, solver=solver,
                     epsilon=epsilon, v_max=v_max)
             except GapFillError as e:
@@ -111,11 +111,11 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
                     lambda x: compound_name.get(x, x))
                 print('{}\t{}\t{}'.format(rxnid, 'Add', rxt))
 
-            for rxnid in sorted(reversed_reactions):
+            for rxnid in sorted(no_bounds_reactions):
                 rx = model_complete.get_reaction(rxnid)
                 rxt = rx.translated_compounds(
                     lambda x: compound_name.get(x, x))
-                print('{}\t{}\t{}'.format(rxnid, 'Reverse', rxt))
+                print('{}\t{}\t{}'.format(rxnid, 'Remove bounds', rxt))
         else:
             logger.info('No blocked compounds found')
 

--- a/psamm/gapfill.py
+++ b/psamm/gapfill.py
@@ -37,9 +37,8 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
     the only factor that influences whether a compound can be
     produced is the presence of the compounds needed to produce it.
 
-    Epsilon indicates the threshold amount of a compound produced
-    for it to not be considered blocked. V_max indicates the
-    maximum flux.
+    Epsilon indicates the threshold amount of reaction flux for the products
+    to be considered non-blocked. V_max indicates the maximum flux.
 
     This method is implemented as a MILP-program. Therefore it may
     not be efficient for larger models.
@@ -57,17 +56,20 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
     binary_cons_lhs = {compound: 0 for compound in model.compounds}
     for spec, value in iteritems(model.matrix):
         compound, reaction_id = spec
-        if value != 0 and (reaction_id in model.reversible or value > 0):
+        if value != 0:
             w.define([spec])
             w_var = w(spec)
-            sv = v(reaction_id) * float(value)
 
-            prob.add_linear_constraints(sv <= v_max * w_var)
-            if model.is_reversible(reaction_id):
-                prob.add_linear_constraints(
-                    sv >= epsilon - v_max * (1 - w_var))
+            lower, upper = (float(x) for x in model.limits[reaction_id])
+            if value > 0:
+                dv = v(reaction_id)
             else:
-                prob.add_linear_constraints(sv >= epsilon * w_var)
+                dv = -v(reaction_id)
+                lower, upper = -upper, -lower
+
+            prob.add_linear_constraints(
+                dv <= upper * w_var,
+                dv >= epsilon + (lower - epsilon) * (1 - w_var))
 
             binary_cons_lhs[compound] += w_var
 
@@ -103,7 +105,8 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
 
     Returns two iterators: first an iterator of reactions not in
     core, that were added to resolve the model. Second, an
-    iterator of reaction in core, that were reversed. Similarly to
+    iterator of reactions in core that had flux bounds expanded (i.e.
+    irreversible reactions become reversible). Similarly to
     GapFind, this method assumes implicit sinks for all compounds in
     the model so the only factor that influences whether a compound
     can be produced is the presence of the compounds needed to produce
@@ -113,8 +116,8 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
     Core indicates the core set of reactions in the model. GapFill will
     minimize the number of added reactions that are not in core. Blocked
     indicates the set of compounds to be resolved. Epsilon indicates the
-    threshold amount of a compound produced for it to not be considered
-    blocked. V_max indicates the maximum flux.
+    threshold amount of a reaction flux for the products to be considered
+    produced. V_max indicates the maximum flux.
 
     This method is implemented as a MILP-program. Therefore it may
     not be efficient for larger models.
@@ -126,54 +129,47 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
 
     # Add binary indicator variables
     database_reactions = set(model.reactions).difference(core)
-    ym = prob.namespace(core, types=lp.VariableType.Binary)
+    ym = prob.namespace(model.reactions, types=lp.VariableType.Binary)
     yd = prob.namespace(database_reactions, types=lp.VariableType.Binary)
 
-    objective = ym.sum(core) + yd.sum(database_reactions)
+    objective = ym.sum(model.reactions) + yd.sum(database_reactions)
     prob.set_objective(objective)
 
-    # Add constraints on core reactions
-    for r in core:
-        if model.is_reversible(r):
-            prob.add_linear_constraints(v(r) >= model.limits[r].lower)
-        else:
-            prob.add_linear_constraints(v(r) >= -v_max * ym(r))
-        prob.add_linear_constraints(v(r) <= model.limits[r].upper)
+    # Add constraints on all reactions
+    for reaction_id in model.reactions:
+        lower, upper = (float(x) for x in model.limits[reaction_id])
+
+        # Allow flux bounds to expand up to v_max with penalty
+        delta_lower = min(0, -v_max - lower)
+        delta_upper = max(0, v_max - upper)
+        prob.add_linear_constraints(
+            v(reaction_id) >= lower + ym(reaction_id) * delta_lower,
+            v(reaction_id) <= upper + ym(reaction_id) * delta_upper)
 
     # Add constraints on database reactions
-    for r in database_reactions:
-        prob.add_linear_constraints(v(r) >= yd(r) * model.limits[r].lower)
-        prob.add_linear_constraints(v(r) <= yd(r) * model.limits[r].upper)
+    for reaction_id in database_reactions:
+        lower, upper = model.limits[reaction_id]
+        prob.add_linear_constraints(
+            v(reaction_id) >= yd(reaction_id) * -v_max,
+            v(reaction_id) <= yd(reaction_id) * v_max)
 
     # Define constraints on production of blocked metabolites in reaction
     w = prob.namespace(types=lp.VariableType.Binary)
-    yn = prob.namespace(types=lp.VariableType.Binary)
     binary_cons_lhs = {compound: 0 for compound in blocked}
     for (compound, reaction_id), value in iteritems(model.matrix):
         if compound in blocked and value != 0:
             w.define([(compound, reaction_id)])
             w_var = w((compound, reaction_id))
 
-            sv = float(value) * v(reaction_id)
+            dv = v(reaction_id) if value > 0 else -v(reaction_id)
             prob.add_linear_constraints(
-                sv >= epsilon - v_max * (1 - w_var))
-            prob.add_linear_constraints(sv <= v_max * w_var)
+                dv <= v_max * w_var,
+                dv >= epsilon + (-v_max - epsilon) * (1 - w_var))
 
-            if reaction_id in model.reversible or value > 0:
-                binary_cons_lhs[compound] += w_var
-            elif reaction_id in core:
-                # In this case, we need to perform a logical AND on the w and
-                # ym variables. This is done by introducing another helper
-                # variable, yn.
-                yn.define([(reaction_id, compound)])
-                yn_var = yn((reaction_id, compound))
-                prob.add_linear_constraints(
-                    2 * yn_var <= w_var + ym(reaction_id))
-                binary_cons_lhs[compound] += yn_var
+            binary_cons_lhs[compound] += w_var
 
     for compound, lhs in iteritems(binary_cons_lhs):
-        if compound in blocked:
-            prob.add_linear_constraints(lhs >= 1)
+        prob.add_linear_constraints(lhs >= 1)
 
     # Define mass balance constraints
     massbalance_lhs = {compound: 0 for compound in model.compounds}
@@ -194,9 +190,9 @@ def gapfill(model, core, blocked, solver, epsilon=0.001, v_max=1000):
             if yd.value(reaction_id) > 0.5:
                 yield reaction_id
 
-    def reversed_iter():
-        for reaction_id in core:
+    def no_bounds_iter():
+        for reaction_id in model.reactions:
             if ym.value(reaction_id) > 0.5:
                 yield reaction_id
 
-    return added_iter(), reversed_iter()
+    return added_iter(), no_bounds_iter()


### PR DESCRIPTION
Changes procedure so that epsilon indicates the flux threshold instead of the compound production threshold. In addition, instead of trying to make irreversible reactions reversible, the procedure will more generally try to expand the flux bounds of reactions that are limited to a narrower range than [-v_max; v_max].