### PR TITLE
lp: Allow access to tolerances through property with min/max

### DIFF
--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -32,7 +32,7 @@ from .lp import Constraint as BaseConstraint
 from .lp import Problem as BaseProblem
 from .lp import Result as BaseResult
 from .lp import (Expression, RelationSense, ObjectiveSense, VariableType,
-                 InvalidResultError)
+                 InvalidResultError, ranged_property)
 
 # Module-level logging
 logger = logging.getLogger(__name__)
@@ -313,8 +313,9 @@ class Problem(BaseProblem):
     def result(self):
         return self._result
 
-    @property
+    @ranged_property(min=None, max=None)
     def feasibility_tolerance(self):
+        """Feasibility tolerance."""
         return self._feasibility_tolerance
 
     @feasibility_tolerance.setter
@@ -322,8 +323,9 @@ class Problem(BaseProblem):
         logger.info('Setting feasibility tolerance to {!r}'.format(value))
         self._feasibility_tolerance = value
 
-    @property
+    @ranged_property(min=None, max=None)
     def optimality_tolerance(self):
+        """Optimality tolerance."""
         return self._optimality_tolerance
 
     @optimality_tolerance.setter
@@ -331,8 +333,9 @@ class Problem(BaseProblem):
         logger.info('Setting optimality tolerance to {!r}'.format(value))
         self._optimality_tolerance = value
 
-    @property
+    @ranged_property(min=None, max=None)
     def integrality_tolerance(self):
+        """Integrality tolerance."""
         return self._integrality_tolerance
 
     @integrality_tolerance.setter

--- a/psamm/lpsolver/lp.py
+++ b/psamm/lpsolver/lp.py
@@ -53,6 +53,97 @@ class Product(tuple):
     """A tuple used to represent a variable product."""
 
 
+class _RangedAccessor(object):
+    """Accessor to value bounded by minimum/maximum."""
+    def __init__(self, obj, prop):
+        self._obj = obj
+        self._prop = prop
+
+    @property
+    def value(self):
+        """Value of property."""
+        if self._prop.fget is None:
+            raise AttributeError('Unable to read attribute')
+        return self._prop.fget(self._obj)
+
+    @value.setter
+    def value(self, v):
+        if self._prop.fset is None:
+            raise AttributeError('Unable to write attribute')
+        self._prop.fset(self._obj, v)
+
+    @value.deleter
+    def value(self):
+        if self._prop.fdel is None:
+            raise AttributeError('Unable to delete attribute')
+        self._prop.fdel(self._obj)
+
+    @property
+    def min(self):
+        """Minimum value."""
+        if self._prop.fmin is None:
+            return -_INF
+        return self._prop.fmin(self._obj)
+
+    @property
+    def max(self):
+        """Maximum value."""
+        if self._prop.fmax is None:
+            return _INF
+        return self._prop.fmax(self._obj)
+
+
+class RangedProperty(object):
+    """Numeric property with minimum and maximum values.
+
+    The value attribute is used to get/set the actual value of the propery.
+    The min/max attributes are used to get the bounds. The range is not
+    automatically enforced when the value is set.
+    """
+    def __init__(self, fget=None, fset=None, fdel=None,
+                 fmin=None, fmax=None, doc=None):
+        self.fget = fget
+        self.fset = fset
+        self.fdel = fdel
+        self.fmin = fmin
+        self.fmax = fmax
+
+        if doc is None and fget is not None:
+            doc = fget.__doc__
+        self.__doc__ = doc
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return _RangedAccessor(obj, self)
+
+    def __set__(self, obj, value):
+        raise AttributeError('Unable to set attribute (try value property)')
+
+    def __delete__(self, obj):
+        raise AttributeError('Unable to delete attribute (try value property)')
+
+    def getter(self, fget):
+        return type(self)(
+            fget, self.fset, self.fdel, self.fmin, self.fmax, self.__doc__)
+
+    def setter(self, fset):
+        return type(self)(
+            self.fget, fset, self.fdel, self.fmin, self.fmax, self.__doc__)
+
+    def deleter(self, fdel):
+        return type(self)(
+            self.fget, self.fset, fdel, self.fmin, self.fmax, self.__doc__)
+
+
+def ranged_property(min=None, max=None):
+    """Decorator for creating ranged property with fixed bounds."""
+    min_value = -_INF if min is None else min
+    max_value = _INF if max is None else max
+    return lambda fget: RangedProperty(
+        fget, fmin=lambda obj: min_value, fmax=lambda obj: max_value)
+
+
 @six.python_2_unicode_compatible
 class Expression(object):
     """Represents a linear expression
@@ -593,15 +684,15 @@ class Problem(object):
     def result(self):
         """Result of solved problem"""
 
-    @property
+    @ranged_property(min=None, max=None)
     def feasibility_tolerance(self):
         raise NotImplementedError('Feasiblity tolerance not available')
 
-    @property
+    @ranged_property(min=None, max=None)
     def optimality_tolerance(self):
         raise NotImplementedError('Optimality tolerance not available')
 
-    @property
+    @ranged_property(min=None, max=None)
     def integrality_tolerance(self):
         raise NotImplementedError('Integrality tolerance not available')
 

--- a/psamm/lpsolver/qsoptex.py
+++ b/psamm/lpsolver/qsoptex.py
@@ -31,7 +31,7 @@ from .lp import Constraint as BaseConstraint
 from .lp import Problem as BaseProblem
 from .lp import Result as BaseResult
 from .lp import (Expression, RelationSense, ObjectiveSense, VariableType,
-                 InvalidResultError)
+                 InvalidResultError, ranged_property)
 
 
 class Solver(BaseSolver):
@@ -184,12 +184,14 @@ class Problem(BaseProblem):
     def result(self):
         return self._result
 
-    @property
+    @ranged_property(min=0, max=0)
     def feasibility_tolerance(self):
+        """Feasibility tolerance."""
         return 0
 
-    @property
+    @ranged_property(min=0, max=0)
     def optimality_tolerance(self):
+        """Optimality tolerance."""
         return 0
 
 

--- a/psamm/tests/test_lpsolver_lp.py
+++ b/psamm/tests/test_lpsolver_lp.py
@@ -22,6 +22,72 @@ import unittest
 from psamm.lpsolver import lp
 
 
+class DummyRangedPropertyContainer(object):
+    def __init__(self):
+        self._property_rw = 5
+
+    @lp.ranged_property(min=-5, max=10)
+    def property_ro(self):
+        return 2.0
+
+    @lp.ranged_property(min=-50, max=17)
+    def property_rw(self):
+        return self._property_rw
+
+    @property_rw.setter
+    def property_rw(self, value):
+        self._property_rw = value
+
+    @property_rw.deleter
+    def property_rw(self):
+        self._property_rw = 0
+
+
+class TestRangedProperty(unittest.TestCase):
+    def setUp(self):
+        self.c = DummyRangedPropertyContainer()
+
+    def test_read_property_ro(self):
+        self.assertEqual(self.c.property_ro.value, 2.0)
+
+    def test_write_property_ro(self):
+        with self.assertRaises(AttributeError):
+            self.c.property_ro.value = 3.0
+
+    def test_write_property_base(self):
+        with self.assertRaises(AttributeError):
+            self.c.property_ro = 3.0
+
+    def test_delete_property_base(self):
+        with self.assertRaises(AttributeError):
+            del self.c.property_ro
+
+    def test_delete_property_ro(self):
+        with self.assertRaises(AttributeError):
+            del self.c.property_ro.value
+
+    def test_read_property_ro_bounds(self):
+        self.assertEqual(self.c.property_ro.min, -5)
+        self.assertEqual(self.c.property_ro.max, 10)
+
+    def test_write_property_ro_bounds(self):
+        with self.assertRaises(AttributeError):
+            self.c.property_ro.min = -50
+        with self.assertRaises(AttributeError):
+            self.c.property_ro.max = 100
+
+    def test_read_property_rw(self):
+        self.assertEqual(self.c.property_rw.value, 5)
+
+    def test_write_property_rw(self):
+        self.c.property_rw.value = 10
+        self.assertEqual(self.c.property_rw.value, 10)
+
+    def test_delete_property_rw(self):
+        del self.c.property_rw.value
+        self.assertEqual(self.c.property_rw.value, 0)
+
+
 class TestExpression(unittest.TestCase):
     def test_create_expression(self):
         e = lp.Expression()


### PR DESCRIPTION
Changes the tolerances on solvers to be exposed through an
object that provides access to both the current value and the
minimum/maximum values for each tolerance setting.