### PR TITLE
Gapfill penalty

### DIFF
--- a/psamm/gapfill.py
+++ b/psamm/gapfill.py
@@ -126,7 +126,9 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
             yield compound
 
 
-def gapfill(model, core, blocked, exclude, solver, epsilon=0.001, v_max=1000):
+def gapfill(
+        model, core, blocked, exclude, solver, epsilon=0.001, v_max=1000,
+        weights={}):
     """Find a set of reactions to add such that no compounds are blocked.
 
     Returns two iterators: first an iterator of reactions not in
@@ -165,7 +167,10 @@ def gapfill(model, core, blocked, exclude, solver, epsilon=0.001, v_max=1000):
     ym = prob.namespace(model.reactions, types=lp.VariableType.Binary)
     yd = prob.namespace(database_reactions, types=lp.VariableType.Binary)
 
-    objective = ym.sum(model.reactions) + yd.sum(database_reactions)
+    objective = ym.expr(
+        (rxnid, weights.get(rxnid, 1)) for rxnid in model.reactions)
+    objective += yd.expr(
+        (rxnid, weights.get(rxnid, 1)) for rxnid in database_reactions)
     prob.set_objective(objective)
 
     # Add constraints on all reactions


### PR DESCRIPTION
Continuation of #148. Adds penalty options for gapfill command similar to fastgapfill. Penalties apply to both adding reactions (database reactions) and modifying flux bounds of existing reactions.