### PR TITLE
Write native model

### DIFF
--- a/psamm/tests/test_datasource_native.py
+++ b/psamm/tests/test_datasource_native.py
@@ -22,11 +22,14 @@ import tempfile
 import unittest
 import math
 from decimal import Decimal
+from collections import OrderedDict
 
-from psamm.datasource import native, context
+from psamm.datasource import native, context, entry
 from psamm.reaction import Reaction, Compound, Direction
+from psamm.formula import Formula
 
 from six import StringIO
+import yaml
 
 
 class TestYAMLDataSource(unittest.TestCase):
@@ -511,5 +514,131 @@ class TestCheckId(unittest.TestCase):
         native._check_id(u'\u222b', 'Compound')
 
 
-if __name__ == '__main__':
-    unittest.main()
+class TestNativeModelWriter(unittest.TestCase):
+    def setUp(self):
+        self.writer = native.ModelWriter()
+
+    def test_convert_compound_entry(self):
+        compound = entry.DictCompoundEntry({
+            'id': 'c1',
+            'name': 'Compound 1',
+            'charge': 2,
+            'formula': None,
+            'custom': 'ABC'
+        })
+        d = self.writer.convert_compound_entry(compound)
+        self.assertIsInstance(d, OrderedDict)
+        self.assertEqual(d['id'], 'c1')
+        self.assertEqual(d['name'], 'Compound 1')
+        self.assertEqual(d['charge'], 2)
+        self.assertEqual(d['custom'], 'ABC')
+        self.assertNotIn('formula', d)
+
+    def test_convert_reaction_entry(self):
+        equation = Reaction(
+            Direction.Both, {Compound('c1', 'c'): -1, Compound('c2', 'c'): 1})
+        reaction = entry.DictReactionEntry({
+            'id': 'rxn01234',
+            'name': 'Test reaction',
+            'equation': equation,
+            'custom_property': -34,
+            'another_custom_property': None
+        })
+        d = self.writer.convert_reaction_entry(reaction)
+        self.assertIsInstance(d, OrderedDict)
+        self.assertEqual(d['id'], 'rxn01234')
+        self.assertEqual(d['name'], 'Test reaction')
+        self.assertEqual(d['equation'], equation)
+        self.assertEqual(d['custom_property'], -34)
+        self.assertNotIn('another_custom_property', d)
+
+    def test_write_compounds(self):
+        stream = StringIO()
+        compounds = [
+            entry.DictCompoundEntry({
+                'id': 'c1',
+                'name': 'Compound 1',
+                'charge': 2,
+                'custom': 34.5
+            }),
+            entry.DictCompoundEntry({
+                'id': 'c2',
+                'name': 'Compound 2',
+                'formula': Formula.parse('H2O')
+            })
+        ]
+        self.writer.write_compounds(stream, compounds)
+
+        self.assertEqual(yaml.safe_load(stream.getvalue()), [
+            {
+                'id': 'c1',
+                'name': 'Compound 1',
+                'charge': 2,
+                'custom': 34.5
+            },
+            {
+                'id': 'c2',
+                'name': 'Compound 2',
+                'formula': 'H2O'
+            }
+        ])
+
+    def test_write_compounds_with_properties(self):
+        stream = StringIO()
+        compounds = [
+            entry.DictCompoundEntry({
+                'id': 'c1',
+                'name': 'Compound 1',
+                'charge': 2
+            }),
+            entry.DictCompoundEntry({
+                'id': 'c2',
+                'name': 'Compound 2',
+                'formula': 'H2O'
+            })
+        ]
+        self.writer.write_compounds(stream, compounds, properties={'name'})
+
+        self.assertEqual(yaml.safe_load(stream.getvalue()), [
+            {
+                'id': 'c1',
+                'name': 'Compound 1'
+            },
+            {
+                'id': 'c2',
+                'name': 'Compound 2'
+            }
+        ])
+
+    def test_write_reactions(self):
+        stream = StringIO()
+        reactions = [
+            entry.DictReactionEntry({
+                'id': 'r1',
+                'name': 'Reaction 1',
+                'equation': Reaction(Direction.Both, {})
+            }),
+            entry.DictReactionEntry({
+                'id': 'r2',
+                'name': 'Reaction 2',
+                'equation': Reaction(Direction.Forward, {
+                    Compound('c1', 'c'): -1,
+                    Compound('c2', 'c'): 2
+                })
+            })
+        ]
+        self.writer.write_reactions(stream, reactions)
+
+        # The reaction equation for r1 is invalid (no compounds) and is
+        # therefore skipped.
+        self.assertEqual(yaml.safe_load(stream.getvalue()), [
+            {
+                'id': 'r1',
+                'name': 'Reaction 1'
+            },
+            {
+                'id': 'r2',
+                'name': 'Reaction 2',
+                'equation': '|c1[c]| => (2) |c2[c]|'
+            }
+        ])


### PR DESCRIPTION
The model writing code from psamm-import is copied and adapted as `ModelWriter` in the `native` module. Currently only adds methods for writing YAML reaction and compound files.