### PR TITLE
Add abstract and concrete model entries

### DIFF
--- a/psamm/datasource/entry.py
+++ b/psamm/datasource/entry.py
@@ -1,0 +1,129 @@
+# This file is part of PSAMM.
+#
+# PSAMM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PSAMM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
+
+"""Representation of compound/reaction entries in models."""
+
+import abc
+
+from six import add_metaclass
+
+
+@add_metaclass(abc.ABCMeta)
+class ModelEntry(object):
+    """Abstract model entry."""
+    @abc.abstractproperty
+    def id(self):
+        """Identifier of entry."""
+
+    @property
+    def name(self):
+        """Name of entry (or None)."""
+        return self.properties.get('name')
+
+    @abc.abstractproperty
+    def properties(self):
+        """Properties of entry as a :class:`Mapping` subclass (e.g. dict).
+
+        Note that the properties are not generally mutable.
+        """
+
+    @abc.abstractproperty
+    def filemark(self):
+        """Position of entry in the source file (or None)."""
+
+
+class CompoundEntry(ModelEntry):
+    """Abstract compound entry."""
+    @property
+    def formula(self):
+        """Chemical formula of compound."""
+        return self.properties.get('formula')
+
+    @property
+    def charge(self):
+        """Compound charge value."""
+        return self.properties.get('charge')
+
+
+class ReactionEntry(ModelEntry):
+    """Abstract reaction entry."""
+    @property
+    def equation(self):
+        """Reaction equation."""
+        return self.properties.get('equation')
+
+    @property
+    def genes(self):
+        """Gene association expression."""
+        return self.properties.get('genes')
+
+
+class _BaseDictEntry(ModelEntry):
+    """Base class for concrete entries based on dictionary."""
+    def __init__(self, abstract_type, properties={}, filemark=None):
+        if isinstance(properties, abstract_type):
+            self._id = properties.id
+            self._properties = dict(properties.properties)
+            if filemark is None:
+                filemark = properties.filemark
+        else:
+            if 'id' not in properties:
+                raise ValueError('id not defined in properties')
+            self._id = properties['id']
+            self._properties = dict(properties)
+
+        self._filemark = filemark
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def properties(self):
+        return self._properties
+
+    @property
+    def filemark(self):
+        return self._filemark
+
+
+class DictCompoundEntry(CompoundEntry, _BaseDictEntry):
+    """Compound entry backed by dictionary.
+
+    The given properties dictionary must contain a key 'id' with the
+    identified.
+
+    Args:
+        properties: dict or :class:`CompoundEntry` to construct from.
+        filemark: Where the entry was parsed from (optional)
+    """
+    def __init__(self, *args, **kwargs):
+        super(DictCompoundEntry, self).__init__(CompoundEntry, *args, **kwargs)
+
+
+class DictReactionEntry(ReactionEntry, _BaseDictEntry):
+    """Reaction entry backed by dictionary.
+
+    The given properties dictionary must contain a key 'id' with the
+    identified.
+
+    Args:
+        properties: dict or :class:`ReactionEntry` to construct from.
+        filemark: Where the entry was parsed from (optional)
+    """
+    def __init__(self, *args, **kwargs):
+        super(DictReactionEntry, self).__init__(ReactionEntry, *args, **kwargs)

--- a/psamm/datasource/kegg.py
+++ b/psamm/datasource/kegg.py
@@ -13,207 +13,283 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Module related to loading KEGG database files."""
 
 import re
+from types import FunctionType
+from collections import Mapping
 
 from .context import FileMark
+from .entry import (CompoundEntry as BaseCompoundEntry,
+                    ReactionEntry as BaseReactionEntry)
 from ..reaction import Reaction, Compound, Direction
 from ..expression.affine import Expression
+from ..util import DictView
+
+from six import iteritems, add_metaclass
 
 
 class ParseError(Exception):
     """Exception used to signal errors while parsing"""
 
 
-class CompoundEntry(object):
-    """Representation of entry in KEGG compound file"""
+class KEGGEntry(object):
+    """Base class for KEGG entry with raw values from KEGG."""
 
-    def __init__(self, values, filemark=None):
-        self.values = dict(values)
-        if 'entry' not in values:
-            raise ParseError('Missing compound identifier')
-        self._id, _ = values['entry'][0].split(None, 1)
+    def __init__(self, properties, filemark=None):
+        self._properties = DictView(dict(properties))
         self._filemark = filemark
 
     @property
-    def id(self):
-        return self._id
-
-    @property
-    def name(self):
-        try:
-            return next(self.names)
-        except StopIteration:
-            return None
-
-    @property
-    def names(self):
-        if 'name' in self.values:
-            for line in self.values['name']:
-                for name in line.rstrip(';').split(';'):
-                    yield name.strip()
-
-    @property
-    def reactions(self):
-        if 'reaction' in self.values:
-            for line in self.values['reaction']:
-                for rxnid in line.split():
-                    yield rxnid
-
-    @property
-    def enzymes(self):
-        if 'enzyme' in self.values:
-            for line in self.values['enzyme']:
-                for enzyme in line.split():
-                    yield enzyme
-
-    @property
-    def formula(self):
-        if 'formula' not in self.values:
-            return None
-        return self.values['formula'][0]
-
-    @property
-    def exact_mass(self):
-        if 'exact_mass' not in self.values:
-            return None
-        return float(self.values['exact_mass'][0])
-
-    @property
-    def mol_weight(self):
-        if 'mol_weight' not in self.values:
-            return None
-        return float(self.values['mol_weight'][0])
-
-    @property
-    def pathways(self):
-        if 'pathway' in self.values:
-            for line in self.values['pathway']:
-                pathway, name = line.split(None, 1)
-                yield pathway, name
-
-    @property
-    def dblinks(self):
-        if 'dblinks' in self.values:
-            for line in self.values['dblinks']:
-                database, entry = line.split(':', 1)
-                yield database.strip(), entry.strip()
-
-    @property
-    def comment(self):
-        if 'comment' not in self.values:
-            return None
-        return '\n'.join(self.values['comment'])
-
-    def __getitem__(self, name):
-        if name not in self.values:
-            raise AttributeError('Attribute does not exist: {}'.format(name))
-        return self._values[name]
+    def properties(self):
+        return self._properties
 
     @property
     def filemark(self):
         return self._filemark
 
-    def __repr__(self):
-        return '<CompoundEntry "{}">'.format(self.id)
 
+class _MappedEntry(object):
+    """Base class for KEGG entry with values mapped to standard keys."""
 
-class ReactionEntry(object):
-    """Representation of entry in KEGG reaction file"""
-
-    def __init__(self, values, filemark=None):
-        self.values = dict(values)
-        if 'entry' not in values:
-            raise ParseError('Missing reaction identifier')
-        self._id, _ = values['entry'][0].split(None, 1)
-        self._filemark = filemark
+    def __init__(self, mapper, entry):
+        self._entry = entry
+        self._properties = mapper(self._entry)
 
     @property
     def id(self):
-        return self._id
+        return self._properties['id']
 
     @property
-    def name(self):
+    def properties(self):
+        return self._properties
+
+    @property
+    def raw_entry(self):
+        return self._entry
+
+    @property
+    def filemark(self):
+        return self._entry.filemark
+
+
+class CompoundEntry(_MappedEntry, BaseCompoundEntry):
+    """KEGG entry with mapped compound properties."""
+    def __init__(self, entry):
+        super(CompoundEntry, self).__init__(CompoundMapper, entry)
+
+
+class ReactionEntry(_MappedEntry, BaseReactionEntry):
+    """KEGG entry with mapped reaction properties."""
+    def __init__(self, entry):
+        super(ReactionEntry, self).__init__(ReactionMapper, entry)
+
+
+class _MapperMeta(Mapping.__class__):
+    """Metaclass for mapper that turns methods into cached keys."""
+    def __new__(cls, name, bases, namespace):
+        property_accessors = {}
+        new_namespace = {}
+        for attr_name, attr in iteritems(namespace):
+            if (isinstance(attr, FunctionType) and
+                    not attr_name.startswith('_')):
+                property_accessors[attr_name] = attr
+            else:
+                new_namespace[attr_name] = attr
+
+        def getitem_props(self, key):
+            if key in property_accessors:
+                if key not in self._cache:
+                    self._cache[key] = property_accessors[key](
+                        self, self._entry.properties)
+                return self._cache[key]
+            raise KeyError('key not found: {!r}'.format(key))
+
+        def iter_props(self):
+            return iter(property_accessors)
+
+        def len_props(self):
+            return len(property_accessors)
+
+        new_namespace['__getitem__'] = getitem_props
+        new_namespace['__iter__'] = iter_props
+        new_namespace['__len__'] = len_props
+
+        return super(_MapperMeta, cls).__new__(
+            cls, name, bases, new_namespace)
+
+    def __call__(self, entry, *args, **kwargs):
+        inst = super(_MapperMeta, self).__call__(*args, **kwargs)
+        inst._entry = entry
+        inst._cache = {}
+        return inst
+
+
+@add_metaclass(_MapperMeta)
+class CompoundMapper(Mapping):
+    """Mapper for raw KEGG compound properties to standard properties.
+
+    Public methods are automatically translated into cached properties by the
+    metaclass.
+    """
+    def id(self, raw):
+        return raw['entry'][0].split(None, 1)[0]
+
+    def name(self, raw):
         try:
-            return next(self.names)
+            return next(self._iter_names(raw))
         except StopIteration:
             return None
 
-    @property
-    def names(self):
-        if 'name' in self.values:
-            for line in self.values['name']:
+    def names(self, raw):
+        return list(self._iter_names(raw))
+
+    def reactions(self, raw):
+        return list(self._iter_reactions(raw))
+
+    def enzymes(self, raw):
+        return list(self._iter_enzymes(raw))
+
+    def formula(self, raw):
+        if 'formula' in raw:
+            return raw['formula'][0]
+        return None
+
+    def exact_mass(self, raw):
+        if 'exact_mass' in raw:
+            return float(raw['exact_mass'][0])
+        return None
+
+    def mol_weight(self, raw):
+        if 'mol_weight' in raw:
+            return float(raw['mol_weight'][0])
+        return None
+
+    def pathways(self, raw):
+        return list(self._iter_pathways(raw))
+
+    def dblinks(self, raw):
+        return list(self._iter_dblinks(raw))
+
+    def comment(self, raw):
+        if 'comment' in raw:
+            return '\n'.join(raw['comment'])
+        return None
+
+    def _iter_names(self, raw):
+        if 'name' in raw:
+            for line in raw['name']:
                 for name in line.rstrip(';').split(';'):
                     yield name.strip()
 
-    @property
-    def definition(self):
-        if 'definition' not in self.values:
-            return None
-        return self.values['definition'][0]
+    def _iter_reactions(self, raw):
+        if 'reaction' in raw:
+            for line in raw['reaction']:
+                for rxnid in line.split():
+                    yield rxnid
 
-    @property
-    def equation(self):
-        if 'equation' not in self.values:
-            return None
-        return self.values['equation'][0]
-
-    @property
-    def enzymes(self):
-        if 'enzyme' in self.values:
-            for line in self.values['enzyme']:
+    def _iter_enzymes(self, raw):
+        if 'enzyme' in raw:
+            for line in raw['enzyme']:
                 for enzyme in line.split():
                     yield enzyme
 
-    @property
-    def pathways(self):
-        if 'pathway' in self.values:
-            for line in self.values['pathway']:
+    def _iter_pathways(self, raw):
+        if 'pathway' in raw:
+            for line in raw['pathway']:
                 pathway, name = line.split(None, 1)
                 yield pathway, name
 
-    @property
-    def comment(self):
-        if 'comment' not in self.values:
-            return None
-        return '\n'.join(self.values['comment'])
+    def _iter_dblinks(self, raw):
+        if 'dblinks' in raw:
+            for line in raw['dblinks']:
+                database, entry = line.split(':', 1)
+                yield database.strip(), entry.strip()
 
-    @property
-    def rpairs(self):
-        if 'rpair' in self.values:
-            for line in self.values['rpair']:
+
+@add_metaclass(_MapperMeta)
+class ReactionMapper(Mapping):
+    """Mapper for raw KEGG reaction properties to standard properties.
+
+    Methods are automatically translated into cached properties by the
+    metaclass.
+    """
+    def id(self, raw):
+        return raw['entry'][0].split(None, 1)[0]
+
+    def name(self, raw):
+        try:
+            return next(self._iter_names(raw))
+        except StopIteration:
+            return None
+
+    def names(self, raw):
+        return list(self._iter_names(raw))
+
+    def definition(self, raw):
+        if 'definition' in raw:
+            return raw['definition'][0]
+        return None
+
+    def equation(self, raw):
+        if 'equation' in raw:
+            return raw['equation'][0]
+        return None
+
+    def enzymes(self, raw):
+        return list(self._iter_enzymes(raw))
+
+    def pathways(self, raw):
+        return list(self._iter_pathways(raw))
+
+    def comment(self, raw):
+        if 'comment' in raw:
+            return '\n'.join(raw['comment'])
+        return None
+
+    def rpairs(self, raw):
+        return list(self._iter_rpairs(raw))
+
+    def _iter_names(self, raw):
+        if 'name' in raw:
+            for line in raw['name']:
+                for name in line.rstrip(';').split(';'):
+                    yield name.strip()
+
+    def _iter_enzymes(self, raw):
+        if 'enzyme' in raw:
+            for line in raw['enzyme']:
+                for enzyme in line.split():
+                    yield enzyme
+
+    def _iter_pathways(self, raw):
+        if 'pathway' in raw:
+            for line in raw['pathway']:
+                pathway, name = line.split(None, 1)
+                yield pathway, name
+
+    def _iter_rpairs(self, raw):
+        if 'rpair' in raw:
+            for line in raw['rpair']:
                 pair, compounds, rp_type = line.split(None, 2)
                 compounds = tuple(compounds.split('_', 1))
                 yield pair, compounds, rp_type
 
-    def __getitem__(self, name):
-        if name not in self.values:
-            raise AttributeError('Attribute does not exist: {}'.format(name))
-        return self._values[name]
 
-    @property
-    def filemark(self):
-        return self._filemark
-
-    def __repr__(self):
-        return '<ReactionEntry "{}">'.format(self.id)
-
-
-def _parse_kegg_entries(f, entry_class, context=None):
+def parse_kegg_entries(f, context=None):
     """Iterate over entries in KEGG file."""
 
     section_id = None
     entry_line = None
-    compound = {}
+    properties = {}
     for lineno, line in enumerate(f):
         if line.strip() == '///':
-            # End of compound
+            # End of entry
             mark = FileMark(context, entry_line, 0)
-            yield entry_class(compound, filemark=mark)
-            compound = {}
+            yield KEGGEntry(properties, filemark=mark)
+            properties = {}
             section_id = None
             entry_line = None
         else:
@@ -224,9 +300,9 @@ def _parse_kegg_entries(f, entry_class, context=None):
             m = re.match(r'([A-Z_]+)\s+(.*)', line.rstrip())
             if m is not None:
                 section_id = m.group(1).lower()
-                compound[section_id] = [m.group(2)]
+                properties[section_id] = [m.group(2)]
             elif section_id is not None:
-                compound[section_id].append(line.strip())
+                properties[section_id].append(line.strip())
             else:
                 raise ParseError(
                     'Missing section identifier at line {}'.format(lineno))
@@ -234,12 +310,14 @@ def _parse_kegg_entries(f, entry_class, context=None):
 
 def parse_compound_file(f, context=None):
     """Iterate over the compound entries in the given file."""
-    return _parse_kegg_entries(f, CompoundEntry, context)
+    for entry in parse_kegg_entries(f, context):
+        yield CompoundEntry(entry)
 
 
 def parse_reaction_file(f, context=None):
     """Iterate over the reaction entries in the given file."""
-    return _parse_kegg_entries(f, ReactionEntry, context)
+    for entry in parse_kegg_entries(f, context):
+        yield ReactionEntry(entry)
 
 
 def parse_reaction(s):

--- a/psamm/datasource/modelseed.py
+++ b/psamm/datasource/modelseed.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Module related to loading ModelSEED database files."""
 
@@ -21,6 +21,7 @@ import csv
 import re
 
 from .context import FileMark
+from .entry import CompoundEntry as BaseCompoundEntry
 
 
 class ParseError(Exception):
@@ -33,7 +34,7 @@ def decode_name(s):
     return re.sub(r'&#(\d+);', lambda x: chr(int(x.group(1))), s)
 
 
-class CompoundEntry(object):
+class CompoundEntry(BaseCompoundEntry):
     """Representation of entry in a ModelSEED compound table"""
 
     def __init__(self, id, names, formula, filemark=None):

--- a/psamm/tests/test_yaml.py
+++ b/psamm/tests/test_yaml.py
@@ -273,8 +273,8 @@ class TestYAMLFileSystemData(unittest.TestCase):
         self.assertEqual(compounds[0].properties['name'], 'Water')
         self.assertEqual(compounds[0].formula, 'H2O')
         self.assertEqual(compounds[0].charge, 0)
-        self.assertEqual(compounds[0].kegg, 'C00001')
-        self.assertEqual(compounds[0].cas, '7732-18-5')
+        self.assertEqual(compounds[0].properties['kegg'], 'C00001')
+        self.assertEqual(compounds[0].properties['cas'], '7732-18-5')
 
     def test_parse_compound_yaml_file(self):
         path = self.write_model_file('compounds.yaml', '\n'.join([
@@ -307,7 +307,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
         self.assertEqual(reactions[0].properties['name'], 'Reaction 1')
         self.assertEqual(reactions[0].equation, Reaction(
             Direction.Forward, [(Compound('A'), 1)], [(Compound('B'), 2)]))
-        self.assertEqual(reactions[0].ec, None)
+        self.assertEqual(reactions[0].properties.get('ec'), None)
         self.assertEqual(reactions[0].genes, None)
         self.assertEqual(reactions[0].filemark.filecontext.filepath, path)
         self.assertEqual(reactions[0].filemark.line, 2)

--- a/psamm/util.py
+++ b/psamm/util.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Various utilities."""
 
@@ -146,6 +146,22 @@ class FrozenOrderedSet(collections.Set, collections.Hashable):
 
     def __repr__(self):
         return str('{}({})').format(self.__class__.__name__, list(self))
+
+
+class DictView(collections.Mapping):
+    """An immutable wrapper around another dict-like object."""
+
+    def __init__(self, d):
+        self.__d = d
+
+    def __getitem__(self, key):
+        return self.__d[key]
+
+    def __iter__(self):
+        return iter(self.__d)
+
+    def __len__(self):
+        return len(self.__d)
 
 
 def git_try_describe(repo_path):


### PR DESCRIPTION
Adds abstract and concrete model entries in `psamm.datasource.entry` and changes the data from the `sbml`, `modelseed`, `native` and `kegg` modules to conform to the abstract classes.