### PR TITLE
Split reader part of NativeModel into ModelReader

### DIFF
--- a/psamm/balancecheck.py
+++ b/psamm/balancecheck.py
@@ -53,11 +53,11 @@ def charge_balance(model):
     """
 
     compound_charge = {}
-    for compound in model.parse_compounds():
-        if hasattr(compound, 'charge') and compound.charge is not None:
+    for compound in model.compounds:
+        if compound.charge is not None:
             compound_charge[compound.id] = compound.charge
 
-    for reaction in model.parse_reactions():
+    for reaction in model.reactions:
         charge = reaction_charge(reaction.equation, compound_charge)
         yield reaction, charge
 
@@ -101,7 +101,7 @@ def formula_balance(model):
 
     # Mapping from compound id to formula
     compound_formula = {}
-    for compound in model.parse_compounds():
+    for compound in model.compounds:
         if compound.formula is not None:
             try:
                 f = Formula.parse(compound.formula).flattened()
@@ -111,5 +111,5 @@ def formula_balance(model):
                     'Error parsing formula for compound {}: {}'.format(
                         compound.id, compound.formula), exc_info=True)
 
-    for reaction in model.parse_reactions():
+    for reaction in model.reactions:
         yield reaction, reaction_formula(reaction.equation, compound_formula)

--- a/psamm/commands/chargecheck.py
+++ b/psamm/commands/chargecheck.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from __future__ import unicode_literals
 
@@ -49,10 +49,10 @@ class ChargeBalanceCommand(Command):
         """Run charge balance command"""
 
         # Load compound information
-        compound_name = {}
-        for compound in self._model.parse_compounds():
-            compound_name[compound.id] = (
-                compound.name if compound.name is not None else compound.id)
+        def compound_name(id):
+            if id not in self._model.compounds:
+                return id
+            return self._model.compounds[id].properties.get('name', id)
 
         # Create a set of excluded reactions
         exclude = set(self._args.exclude)
@@ -71,8 +71,7 @@ class ChargeBalanceCommand(Command):
                 unchecked += 1
             elif abs(charge) > self._args.epsilon:
                 unbalanced += 1
-                rxt = reaction.equation.translated_compounds(
-                    lambda x: compound_name.get(x, x))
+                rxt = reaction.equation.translated_compounds(compound_name)
                 print('{}\t{}\t{}'.format(reaction.id, charge, rxt))
 
         logger.info('Unbalanced reactions: {}/{}'.format(unbalanced, count))

--- a/psamm/commands/console.py
+++ b/psamm/commands/console.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from __future__ import unicode_literals
 

--- a/psamm/commands/duplicatescheck.py
+++ b/psamm/commands/duplicatescheck.py
@@ -80,7 +80,7 @@ class DuplicatesCheck(Command):
 
         # Create dictonary of signatures
         database_signatures = {}
-        for entry in self._model.parse_reactions():
+        for entry in self._model.reactions:
             signature = reaction_signature(
                 entry.equation, direction=self._args.compare_direction,
                 stoichiometry=self._args.compare_stoichiometry)

--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -20,10 +20,9 @@ from __future__ import unicode_literals
 
 import logging
 
-from six import text_type
+from six import text_type, itervalues
 
 from ..command import Command
-from .. import util
 
 try:
     import xlsxwriter
@@ -52,36 +51,29 @@ class ExcelExportCommand(Command):
         workbook = xlsxwriter.Workbook(self._args.file)
         reaction_sheet = workbook.add_worksheet(name='Reactions')
 
-        git_version = None
-        if self._model.context is not None:
-            git_version = util.git_try_describe(self._model.context.basepath)
-
         property_set = set()
-        for reaction in model.parse_reactions():
+        for reaction in model.reactions:
             property_set.update(reaction.properties)
         property_list = list(property_set)
         property_list_sorted = sorted(property_list,
                                       key=lambda x: (x != 'id',
                                                      x != 'equation', x))
-        model_reactions = set(model.parse_model())
+        model_reactions = set(model.model)
         for z, i in enumerate(property_list_sorted + ['in_model']):
             reaction_sheet.write_string(0, z, text_type(i))
-        for x, i in enumerate(model.parse_reactions()):
+        for x, i in enumerate(model.reactions):
             for y, j in enumerate(property_list_sorted):
-                reaction_sheet.write_string(
-                    x+1, y, text_type(i.properties.get(j)))
-            if (not model.has_model_definition() or
-                    i.id in model_reactions):
-                reaction_sheet.write_string(
-                    x+1, len(property_list_sorted), 'True')
-            else:
-                reaction_sheet.write_string(
-                    x+1, len(property_list_sorted), 'False')
+                value = i.properties.get(j)
+                if value is not None:
+                    reaction_sheet.write_string(x+1, y, text_type(value))
+            reaction_sheet.write_string(
+                x+1, len(property_list_sorted),
+                text_type(i.id in model_reactions))
 
         compound_sheet = workbook.add_worksheet(name='Compounds')
 
         compound_set = set()
-        for compound in model.parse_compounds():
+        for compound in model.compounds:
             compound_set.update(compound.properties)
 
         compound_list_sorted = sorted(compound_set,
@@ -92,17 +84,14 @@ class ExcelExportCommand(Command):
         model_compounds = set(x.name for x in metabolic_model.compounds)
         for z, i in enumerate(compound_list_sorted + ['in_model']):
             compound_sheet.write_string(0, z, text_type(i))
-        for x, i in enumerate(model.parse_compounds()):
+        for x, i in enumerate(model.compounds):
             for y, j in enumerate(compound_list_sorted):
-                compound_sheet.write_string(
-                    x+1, y, text_type(i.properties.get(j)))
-            if (not self._model.has_model_definition() or
-                    i.id in model_compounds):
-                compound_sheet.write_string(
-                    x+1, len(compound_list_sorted), 'True')
-            else:
-                compound_sheet.write_string(
-                    x+1, len(compound_list_sorted), 'False')
+                value = i.properties.get(j)
+                if value is not None:
+                    compound_sheet.write_string(x+1, y, text_type(value))
+            compound_sheet.write_string(
+                x+1, len(compound_list_sorted),
+                text_type(i.id in model_compounds))
 
         exchange_sheet = workbook.add_worksheet(name='Exchange')
 
@@ -114,9 +103,9 @@ class ExcelExportCommand(Command):
         default_flux = model.default_flux_limit
 
         for x, (compound, reaction, lower, upper) in enumerate(
-                model.parse_exchange()):
+                itervalues(model.exchange)):
             if lower is None:
-                lower = -1 * default_flux
+                lower = -default_flux
 
             if upper is None:
                 upper = default_flux
@@ -132,7 +121,7 @@ class ExcelExportCommand(Command):
         limits_sheet.write_string(0, 1, 'Lower Limit')
         limits_sheet.write_string(0, 2, 'Upper Limit')
 
-        for x, limit in enumerate(model.parse_limits()):
+        for x, limit in enumerate(itervalues(model.limits)):
             reaction_id, lower, upper = limit
             if lower is None:
                 lower = -default_flux
@@ -151,7 +140,8 @@ class ExcelExportCommand(Command):
             1, 0, ('Biomass Reaction: {}'.format(model.biomass_reaction)))
         model_info.write(
             2, 0, ('Default Flux Limits: {}'.format(model.default_flux_limit)))
-        if git_version is not None:
-            model_info.write(3, 0, ('Git version: {}'.format(git_version)))
+        if model.version_string is not None:
+            model_info.write(
+                3, 0, ('Version: {}'.format(model.version_string)))
 
         workbook.close()

--- a/psamm/commands/fastgapfill.py
+++ b/psamm/commands/fastgapfill.py
@@ -59,10 +59,10 @@ class FastGapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
         solver = self._get_solver()
 
         # Load compound information
-        compound_name = {}
-        for compound in self._model.parse_compounds():
-            compound_name[compound.id] = (
-                compound.name if compound.name is not None else compound.id)
+        def compound_name(id):
+            if id not in self._model.compounds:
+                return id
+            return self._model.compounds[id].properties.get('name', id)
 
         # TODO: The exchange and transport reactions have tuple names. This
         # means that in Python 3 the reactions can no longer be directly
@@ -106,15 +106,13 @@ class FastGapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
 
         for reaction_id in sorted(self._mm.reactions):
             rx = self._mm.get_reaction(reaction_id)
-            rxt = rx.translated_compounds(
-                lambda x: compound_name.get(x, x))
+            rxt = rx.translated_compounds(compound_name)
             print('{}\t{}\t{}\t{}'.format(reaction_id, 'Model', 0, rxt))
 
         for rxnid in sorted(induced, key=reaction_key):
             if self._mm.has_reaction(rxnid):
                 continue
             rx = model_extended.get_reaction(rxnid)
-            rxt = rx.translated_compounds(
-                lambda x: compound_name.get(x, x))
+            rxt = rx.translated_compounds(compound_name)
             print('{}\t{}\t{}\t{}'.format(
                 rxnid, 'Add', weights.get(rxnid, 1), rxt))

--- a/psamm/commands/fluxcheck.py
+++ b/psamm/commands/fluxcheck.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from __future__ import unicode_literals
 
@@ -63,12 +63,10 @@ class FluxConsistencyCommand(MetabolicMixin, LoopRemovalMixin,
         """Run flux consistency check command"""
 
         # Load compound information
-        compound_name = {}
-        for compound in self._model.parse_compounds():
-            if 'name' in compound.properties:
-                compound_name[compound.id] = compound.properties['name']
-            elif compound.id not in compound_name:
-                compound_name[compound.id] = compound.id
+        def compound_name(id):
+            if id not in self._model.compounds:
+                return id
+            return self._model.compounds[id].properties.get('name', id)
 
         epsilon = self._args.epsilon
 
@@ -148,8 +146,7 @@ class FluxConsistencyCommand(MetabolicMixin, LoopRemovalMixin,
 
             if reaction in inconsistent:
                 rx = self._mm.get_reaction(reaction)
-                rxt = rx.translated_compounds(
-                    lambda x: compound_name.get(x, x))
+                rxt = rx.translated_compounds(compound_name)
                 print('{}\t{}'.format(reaction, rxt))
 
         logger.info('Model has {}/{} inconsistent internal reactions'

--- a/psamm/commands/fva.py
+++ b/psamm/commands/fva.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from __future__ import unicode_literals
 
@@ -47,12 +47,10 @@ class FluxVariabilityCommand(MetabolicMixin, SolverCommandMixin,
         """Run flux variability command"""
 
         # Load compound information
-        compound_name = {}
-        for compound in self._model.parse_compounds():
-            if 'name' in compound.properties:
-                compound_name[compound.id] = compound.properties['name']
-            elif compound.id not in compound_name:
-                compound_name[compound.id] = compound.id
+        def compound_name(id):
+            if id not in self._model.compounds:
+                return id
+            return self._model.compounds[id].properties.get('name', id)
 
         reaction = self._get_objective()
         if not self._mm.has_reaction(reaction):
@@ -107,7 +105,7 @@ class FluxVariabilityCommand(MetabolicMixin, SolverCommandMixin,
 
         for reaction_id, (lower, upper) in iter_results():
             rx = self._mm.get_reaction(reaction_id)
-            rxt = rx.translated_compounds(lambda x: compound_name.get(x, x))
+            rxt = rx.translated_compounds(compound_name)
             print('{}\t{}\t{}\t{}'.format(reaction_id, lower, upper, rxt))
 
         logger.info('Solving took {:.2f} seconds'.format(

--- a/psamm/commands/gapcheck.py
+++ b/psamm/commands/gapcheck.py
@@ -54,12 +54,10 @@ class GapCheckCommand(MetabolicMixin, SolverCommandMixin, Command):
 
     def run(self):
         # Load compound information
-        compound_name = {}
-        for compound in self._model.parse_compounds():
-            if 'name' in compound.properties:
-                compound_name[compound.id] = compound.properties['name']
-            elif compound.id not in compound_name:
-                compound_name[compound.id] = compound.id
+        def compound_name(id):
+            if id not in self._model.compounds:
+                return id
+            return self._model.compounds[id].properties.get('name', id)
 
         extracellular_comp = self._model.extracellular_compartment
         epsilon = self._args.epsilon
@@ -107,8 +105,7 @@ class GapCheckCommand(MetabolicMixin, SolverCommandMixin, Command):
                 continue
 
             count += 1
-            name = compound_name.get(compound.name, compound.name)
-            print('{}\t{}'.format(compound, name))
+            print('{}\t{}'.format(compound, compound_name(compound.name)))
 
         logger.info('Blocked compounds: {}'.format(count))
 

--- a/psamm/commands/gapfill.py
+++ b/psamm/commands/gapfill.py
@@ -67,12 +67,10 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
         """Run GapFill command"""
 
         # Load compound information
-        compound_name = {}
-        for compound in self._model.parse_compounds():
-            if 'name' in compound.properties:
-                compound_name[compound.id] = compound.properties['name']
-            elif compound.id not in compound_name:
-                compound_name[compound.id] = compound.id
+        def compound_name(id):
+            if id not in self._model.compounds:
+                return id
+            return self._model.compounds[id].properties.get('name', id)
 
         # Calculate penalty if penalty file exists
         penalties = {}
@@ -133,21 +131,18 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
 
         for reaction_id in sorted(self._mm.reactions):
             rx = self._mm.get_reaction(reaction_id)
-            rxt = rx.translated_compounds(
-                lambda x: compound_name.get(x, x))
+            rxt = rx.translated_compounds(compound_name)
             print('{}\t{}\t{}\t{}'.format(reaction_id, 'Model', 0, rxt))
 
         for rxnid in sorted(added_reactions):
             rx = model_complete.get_reaction(rxnid)
-            rxt = rx.translated_compounds(
-                lambda x: compound_name.get(x, x))
+            rxt = rx.translated_compounds(compound_name)
             print('{}\t{}\t{}\t{}'.format(
                 rxnid, 'Add', weights.get(rxnid, 1), rxt))
 
         for rxnid in sorted(no_bounds_reactions):
             rx = model_complete.get_reaction(rxnid)
-            rxt = rx.translated_compounds(
-                lambda x: compound_name.get(x, x))
+            rxt = rx.translated_compounds(compound_name)
             print('{}\t{}\t{}\t{}'.format(
                 rxnid, 'Remove bounds', weights.get(rxnid, 1), rxt))
 

--- a/psamm/commands/genedelete.py
+++ b/psamm/commands/genedelete.py
@@ -49,7 +49,7 @@ class GeneDeletionCommand(MetabolicMixin, ObjectiveMixin, SolverCommandMixin,
 
         genes = set()
         gene_assoc = {}
-        for reaction in self._model.parse_reactions():
+        for reaction in self._model.reactions:
             assoc = None
             if reaction.genes is None:
                 continue

--- a/psamm/commands/robustness.py
+++ b/psamm/commands/robustness.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from __future__ import unicode_literals
 
@@ -62,14 +62,6 @@ class RobustnessCommand(MetabolicMixin, LoopRemovalMixin, ObjectiveMixin,
 
     def run(self):
         """Run robustness command."""
-
-        # Load compound information
-        compound_name = {}
-        for compound in self._model.parse_compounds():
-            if 'name' in compound.properties:
-                compound_name[compound.id] = compound.properties['name']
-            elif compound.id not in compound_name:
-                compound_name[compound.id] = compound.id
 
         reaction = self._get_objective()
         if not self._mm.has_reaction(reaction):

--- a/psamm/commands/search.py
+++ b/psamm/commands/search.py
@@ -75,7 +75,7 @@ class SearchCommand(Command):
     def _search_compound(self):
         selected_compounds = set()
 
-        for compound in self._model.parse_compounds():
+        for compound in self._model.compounds:
             if len(self._args.id) > 0:
                 if any(c == compound.id for c in self._args.id):
                     selected_compounds.add(compound)
@@ -107,7 +107,7 @@ class SearchCommand(Command):
 
         # Prepare translation table from compound id to name
         compound_name = {}
-        for compound in self._model.parse_compounds():
+        for compound in self._model.compounds:
             if 'name' in compound.properties:
                 compound_name[compound.id] = compound.properties['name']
 
@@ -119,7 +119,7 @@ class SearchCommand(Command):
                 compound_set.add(parse_compound(compound_spec.strip()))
             search_compounds.append(compound_set)
 
-        for reaction in self._model.parse_reactions():
+        for reaction in self._model.reactions:
             if len(self._args.id) > 0:
                 if any(r == reaction.id for r in self._args.id):
                     selected_reactions.add(reaction)

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -47,12 +47,10 @@ from .entry import (DictCompoundEntry as CompoundEntry,
                     DictCompartmentEntry as CompartmentEntry)
 from .reaction import ReactionParser
 from . import modelseed
+from .. import util
 
 # Module-level logging
 logger = logging.getLogger(__name__)
-
-# Model files to try to open if a directory was specified
-DEFAULT_MODEL = ('model.yaml', 'model.yml')
 
 _HAS_YAML_LIBRARY = None
 
@@ -73,11 +71,6 @@ def float_constructor(loader, node):
     elif s == '.nan':
         return Decimal('NaN')
     return Decimal(s)
-
-
-def whendefined(func, value):
-    """Apply func to value if value is not None"""
-    return func(value) if value is not None else None
 
 
 def yaml_load(stream):
@@ -101,14 +94,56 @@ def yaml_load(stream):
     return loader.get_data()
 
 
-class NativeModel(object):
-    """Represents a model specified using the native data formats
+class _OrderedEntrySet(object):
+    """Ordered set of entity entries.
 
-    The model is created from a model file or from a directory containing a
-    model file using the default file name (model.yaml or model.yml). This file
-    can specify the model fully or refer to other files within the same
-    directory subtree that specifies part of the model.
+    This deliberately does not implement Mapping because iteration does not
+    provide keys (since the keys are already in the entry values).
     """
+    def __init__(self, mapping={}):
+        self._dict = OrderedDict(mapping)
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def get(self, key, default=None):
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __iter__(self):
+        return itervalues(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def add_entry(self, entry):
+        self._dict[entry.id] = entry
+
+    def discard(self, key):
+        try:
+            del self._dict[key]
+        except KeyError:
+            pass
+
+
+class ModelReader(object):
+    """Reader of native YAML-based model format.
+
+    The reader can be created from a model YAML file or directly from a
+    dict, string or File-like object. Use :meth:`reader_from_path` to read the
+    model from a YAML file or directory and use the constructor to read from
+    other sources. Any externally referenced file (with ``include``) will be
+    read on demand by the parse methods. To read the model fully into memory,
+    use the :meth:`create_model` to create a :class:`NativeModel`.
+    """
+
+    # Model files to try to open if a directory was specified
+    DEFAULT_MODEL = 'model.yaml', 'model.yml'
 
     def __init__(self, model_from, context=None):
         """Create a model from the specified content.
@@ -128,27 +163,69 @@ class NativeModel(object):
             raise ValueError("Model is of an invalid types")
 
     @classmethod
-    def load_model_from_path(cls, path):
-        """Create a model from specified path."""
+    def reader_from_path(cls, path):
+        """Create a model from specified path.
+
+        Path can be a directory containing a ``model.yaml`` or ``model.yml``
+        file or it can be a path naming the central model file directly.
+        """
         context = FilePathContext(path)
         try:
             with open(context.filepath, 'r') as f:
-                return NativeModel(f, context)
+                return ModelReader(f, context)
         except IOError:
             # Try to open the default file
-            for filename in DEFAULT_MODEL:
+            for filename in cls.DEFAULT_MODEL:
                 try:
                     context = FilePathContext(
                         os.path.join(path, filename))
                     with open(context.filepath, 'r') as f:
-                        return NativeModel(f, context)
+                        return ModelReader(f, context)
                 except:
                     logger.debug('Failed to load model file',
                                  exc_info=True)
 
         # No model could be loaded
         raise ParseError('No model file could be found ({})'.format(
-            ', '.join(DEFAULT_MODEL)))
+            ', '.join(cls.DEFAULT_MODEL)))
+
+    @property
+    def name(self):
+        """Name specified by the model."""
+        return self._model.get('name', None)
+
+    @property
+    def biomass_reaction(self):
+        """Biomass reaction specified by the model."""
+        return self._model.get('biomass', None)
+
+    @property
+    def extracellular_compartment(self):
+        """Extracellular compartment specified by the model.
+
+        Defaults to 'e'.
+        """
+        return self._model.get('extracellular', 'e')
+
+    @property
+    def default_compartment(self):
+        """Default compartment specified by the model.
+
+        The compartment that is implied when not specified. In some contexts
+        (e.g. for exchange compounds) the extracellular compartment may be
+        implied instead. Defaults to 'c'.
+        """
+        return self._model.get('default_compartment', 'c')
+
+    @property
+    def default_flux_limit(self):
+        """Default flux limit specified by the model.
+
+        When flux limits on reactions are not specified, this value will be
+        used. Flux limit of [0;x] will be implied for irreversible reactions
+        and [-x;x] for reversible reactions, where x is this value.
+        Defaults to 1000."""
+        return self._model.get('default_flux_limit', 1000)
 
     def parse_compartments(self):
         """Parse compartment information from model.
@@ -194,44 +271,6 @@ class NativeModel(object):
                     boundaries.add(tuple(sorted((source, dest))))
 
         return itervalues(compartments), frozenset(boundaries)
-
-    @property
-    def name(self):
-        """Name specified by the model."""
-        return self._model.get('name', None)
-
-    @property
-    def biomass_reaction(self):
-        """Biomass reaction specified by the model."""
-        return self._model.get('biomass', None)
-
-    @property
-    def extracellular_compartment(self):
-        """Extracellular compartment specified by the model.
-
-        Defaults to 'e'.
-        """
-        return self._model.get('extracellular', 'e')
-
-    @property
-    def default_compartment(self):
-        """Default compartment specified by the model.
-
-        The compartment that is implied when not specified. In some contexts
-        (e.g. for exchange compounds) the extracellular compartment may be
-        implied instead. Defaults to 'c'.
-        """
-        return self._model.get('default_compartment', 'c')
-
-    @property
-    def default_flux_limit(self):
-        """Default flux limit specified by the model.
-
-        When flux limits on reactions are not specified, this value will be
-        used. Flux limit of [0;x] will be implied for irreversible reactions
-        and [-x;x] for reversible reactions, where x is this value.
-        Defaults to 1000."""
-        return self._model.get('default_flux_limit', 1000)
 
     def parse_reactions(self):
         """Yield tuples of reaction ID and reactions defined in the model"""
@@ -310,25 +349,186 @@ class NativeModel(object):
                     self._context, self._model['compounds']):
                 yield compound
 
+    @property
+    def context(self):
+        return self._context
+
+    def create_model(self):
+        """Return :class:`NativeModel` fully loaded into memory."""
+
+        properties = {
+            'name': self.name,
+            'biomass': self.biomass_reaction,
+            'extracellular': self.extracellular_compartment,
+            'default_compartment': self.default_compartment,
+            'default_flux_limit': self.default_flux_limit
+        }
+
+        if self.context is not None:
+            git_version = util.git_try_describe(self.context.basepath)
+            properties['version_string'] = git_version
+
+        model = NativeModel(properties)
+
+        # Load compartments into model
+        compartment_iter, boundaries = self.parse_compartments()
+        for compartment in compartment_iter:
+            model.compartments.add_entry(compartment)
+        model.compartment_boundaries.update(boundaries)
+
+        # Load compounds into model
+        for compound in self.parse_compounds():
+            if compound.id in model.compounds:
+                existing_entry = model.compounds[compound.id]
+                common_props = set(compound.properties).intersection(
+                    existing_entry.properties).difference({'id'})
+                if len(common_props) > 0:
+                    logger.warning(
+                        'Compound entry {} at {} overrides already defined'
+                        ' properties: {}'.format(
+                            compound.id, compound.filemark, common_props))
+
+                properties = dict(compound.properties)
+                properties.update(existing_entry.properties)
+                compound = CompoundEntry(
+                    properties, filemark=compound.filemark)
+            model.compounds.add_entry(compound)
+
+        # Load reactions into model
+        for reaction in self.parse_reactions():
+            if reaction.id in model.reactions:
+                existing_entry = model.reactions[reaction.id]
+                common_props = set(reaction.properties).intersection(
+                    existing_entry.properties).difference({'id'})
+                if len(common_props) > 0:
+                    logger.warning(
+                        'Reaction entry {} at {} overrides already defined'
+                        ' properties: {}'.format(
+                            reaction.id, reaction.filemark, common_props))
+
+                properties = dict(reaction.properties)
+                properties.update(existing_entry.properties)
+                reaction = ReactionEntry(
+                    properties, filemark=reaction.filemark)
+            model.reactions.add_entry(reaction)
+
+        for exchange_def in self.parse_exchange():
+            model.exchange[exchange_def[0]] = exchange_def
+
+        for limit in self.parse_limits():
+            model.limits[limit[0]] = limit
+
+        if self.has_model_definition():
+            for model_reaction in self.parse_model():
+                model.model[model_reaction] = None
+        else:
+            for reaction in model.reactions:
+                model.model[reaction.id] = None
+
+        return model
+
+
+class NativeModel(object):
+    """Represents model in the native format."""
+
+    def __init__(self, properties={}):
+        self._properties = dict(properties)
+        self._compartments = _OrderedEntrySet()
+        self._compartment_boundaries = set()
+        self._compounds = _OrderedEntrySet()
+        self._reactions = _OrderedEntrySet()
+        self._exchange = OrderedDict()
+        self._limits = OrderedDict()
+        self._model = OrderedDict()
+
+    @property
+    def name(self):
+        """Return model name property."""
+        return self._properties.get('name')
+
+    @property
+    def version_string(self):
+        """Return model version string."""
+        return self._properties.get('version_string')
+
+    @property
+    def biomass_reaction(self):
+        """Return biomass reaction property."""
+        return self._properties.get('biomass')
+
+    @property
+    def extracellular_compartment(self):
+        """Return extracellular compartment property."""
+        return self._properties.get('extracellular')
+
+    @property
+    def default_compartment(self):
+        """Return default compartment property."""
+        return self._properties.get('default_compartment')
+
+    @property
+    def default_flux_limit(self):
+        """Return default flux limit property."""
+        return self._properties.get('default_flux_limit')
+
+    @property
+    def compartments(self):
+        """Return compartments entry set."""
+        return self._compartments
+
+    @property
+    def compartment_boundaries(self):
+        """Return set of compartment boundaries."""
+        return self._compartment_boundaries
+
+    @property
+    def reactions(self):
+        """Return reaction entry set."""
+        return self._reactions
+
+    @property
+    def compounds(self):
+        """Return compound entry set."""
+        return self._compounds
+
+    @property
+    def exchange(self):
+        """Return dict of exchange compounds and properties."""
+        return self._exchange
+
+    @property
+    def limits(self):
+        """Return dict of reaction limits."""
+        return self._limits
+
+    @property
+    def model(self):
+        """Return dict of model reactions."""
+        return self._model
+
     def create_metabolic_model(self):
         """Create a :class:`psamm.metabolicmodel.MetabolicModel`."""
 
+        def _translate_compartments(reaction, compartment):
+            """Translate compound with missing compartments.
+
+            These compounds will have the specified compartment in the output.
+            """
+            left = (((c.in_compartment(compartment), v)
+                     if c.compartment is None else (c, v))
+                    for c, v in reaction.left)
+            right = (((c.in_compartment(compartment), v)
+                      if c.compartment is None else (c, v))
+                     for c, v in reaction.right)
+            return Reaction(reaction.direction, left, right)
+
         # Create metabolic model
         database = DictDatabase()
-        for reaction in self.parse_reactions():
+        for reaction in self.reactions:
             if reaction.equation is not None:
-                database.set_reaction(reaction.id, reaction.equation)
-
-        # Warn about undefined compartments
-        compartments = set()
-        compartments_iter, boundaries = self.parse_compartments()
-        for compartment in compartments_iter:
-            compartments.add(compartment.id)
-
-        # Warn about undefined compounds
-        compounds = set()
-        for compound in self.parse_compounds():
-            compounds.add(compound.id)
+                equation = _translate_compartments(
+                    reaction.equation, self.default_compartment)
+                database.set_reaction(reaction.id, equation)
 
         undefined_compartments = set()
         undefined_compounds = set()
@@ -336,11 +536,11 @@ class NativeModel(object):
         extracellular = self.extracellular_compartment
         for reaction in database.reactions:
             for compound, _ in database.get_reaction_values(reaction):
-                if compound.name not in compounds:
+                if compound.name not in self.compounds:
                     undefined_compounds.add(compound.name)
                 if compound.compartment == extracellular:
                     extracellular_compounds.add(compound.name)
-                if compound.compartment not in compartments:
+                if compound.compartment not in self.compartments:
                     undefined_compartments.add(compound.compartment)
 
         for compartment in sorted(undefined_compartments):
@@ -354,9 +554,9 @@ class NativeModel(object):
                 ' of compounds'.format(compound))
 
         exchange_compounds = set()
-        for compound, _, _, _ in self.parse_exchange():
-            if compound.compartment == extracellular:
-                exchange_compounds.add(compound.name)
+        for exchange_compound in self.exchange:
+            if exchange_compound.compartment == extracellular:
+                exchange_compounds.add(exchange_compound.name)
 
         for compound in sorted(extracellular_compounds - exchange_compounds):
             logger.warning(
@@ -368,17 +568,12 @@ class NativeModel(object):
                 ' is not in the extracellular compartment'.format(compound))
 
         model_definition = None
-        if self.has_model_definition():
-            model_definition = self.parse_model()
+        if len(self.model) > 0:
+            model_definition = self.model
 
         return MetabolicModel.load_model(
-            database, model_definition, self.parse_exchange(),
-            self.parse_limits(), v_max=self.default_flux_limit)
-
-    @property
-    def context(self):
-        """Model file loading context (or None, if undefined)."""
-        return self._context
+            database, model_definition, itervalues(self.exchange),
+            itervalues(self.limits), v_max=self.default_flux_limit)
 
 
 def _check_id(entity, entity_type):

--- a/psamm/gapfilling.py
+++ b/psamm/gapfilling.py
@@ -175,9 +175,8 @@ def create_extended_model(model, db_penalty=None, ex_penalty=None,
     # Create metabolic model
     model_extended = model.create_metabolic_model()
     extra_compartment = model.extracellular_compartment
-    compartments, boundaries = model.parse_compartments()
 
-    compartment_ids = set(c.id for c in compartments)
+    compartment_ids = set(c.id for c in model.compartments)
 
     # Add database reactions to extended model
     if len(compartment_ids) > 0:
@@ -200,6 +199,7 @@ def create_extended_model(model, db_penalty=None, ex_penalty=None,
         model_extended, extra_compartment, allow_duplicates=True)
 
     # Add transport reactions to extended model
+    boundaries = model.compartment_boundaries
     if len(boundaries) > 0:
         logger.info(
             'Using artificial transport reactions for the compartment'

--- a/psamm/randomsparse.py
+++ b/psamm/randomsparse.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 # Copyright 2015  Keith Dufault-Thompson <keitht547@my.uri.edu>
 # Copyright 2016  Chao Liu <lcddzyx@gmail.com>
 
@@ -123,7 +123,7 @@ def get_gene_associations(model):
         model: :class:`psamm.datasource.native.NativeModel`.
     """
 
-    for reaction in model.parse_reactions():
+    for reaction in model.reactions:
         assoc = None
         if reaction.genes is None:
             continue

--- a/psamm/tests/test_balancecheck.py
+++ b/psamm/tests/test_balancecheck.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 # Copyright 2016  Chao liu <lcddzyx@gmail.com>
 
 import os
@@ -23,7 +23,7 @@ import shutil
 import math
 
 from psamm.formula import Formula
-from psamm.datasource.native import NativeModel
+from psamm.datasource.native import ModelReader
 from psamm import balancecheck
 from psamm.datasource.reaction import parse_reaction
 
@@ -54,7 +54,8 @@ class TestBalanceCheckWithModel(unittest.TestCase):
                 '  - id: D',
                 '    formula: H2O',
             ]))
-        self._model = NativeModel.load_model_from_path(self._model_dir)
+        self._model = ModelReader.reader_from_path(
+            self._model_dir).create_model()
 
     def tearDown(self):
         shutil.rmtree(self._model_dir)

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -31,7 +31,7 @@ from six import StringIO, BytesIO
 from psamm.command import (main, Command, MetabolicMixin, SolverCommandMixin,
                            CommandError)
 from psamm.lpsolver import generic
-from psamm.datasource.native import NativeModel
+from psamm.datasource import native
 
 from psamm.commands.chargecheck import ChargeBalanceCommand
 from psamm.commands.duplicatescheck import DuplicatesCheck
@@ -107,7 +107,7 @@ class MockSolverCommand(SolverCommandMixin, Command):
 
 class TestCommandMain(unittest.TestCase):
     def setUp(self):
-        self._model = NativeModel({
+        reader = native.ModelReader({
             'name': 'Test model',
             'biomass': 'rxn_1',
             'compartments': [
@@ -172,8 +172,9 @@ class TestCommandMain(unittest.TestCase):
                 }
             ]
         })
+        self._model = reader.create_model()
 
-        self._infeasible_model = NativeModel({
+        reader = native.ModelReader({
             'biomass': 'rxn_1',
             'reactions': [
                 {
@@ -188,6 +189,7 @@ class TestCommandMain(unittest.TestCase):
                 }
             ]
         })
+        self._infeasible_model = reader.create_model()
 
     def assertTableOutputEqual(self, output, table):
         self.assertEqual(

--- a/psamm/tests/test_datasource_native.py
+++ b/psamm/tests/test_datasource_native.py
@@ -57,8 +57,8 @@ class TestYAMLDataSource(unittest.TestCase):
                 }
             ]
         }
-        model = native.NativeModel(model_dict)
-        compartment_iter, boundaries = model.parse_compartments()
+        reader = native.ModelReader(model_dict)
+        compartment_iter, boundaries = reader.parse_compartments()
         compartments = list(compartment_iter)
 
         self.assertEqual(len(compartments), 4)
@@ -214,7 +214,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
               - reaction: rxn_2_\u03c0
                 upper: 100
             '''
-        m = native.NativeModel(long_string)
+        m = native.ModelReader(long_string)
         self.assertEqual(m.name, 'Test model')
         self.assertEqual(m.biomass_reaction, 'rxn_1')
         self.assertEqual(m.extracellular_compartment, 'e')
@@ -228,7 +228,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
             reactions:
               - include: exchange.yaml
             '''
-        m = native.NativeModel(longString)
+        m = native.ModelReader(longString)
         with self.assertRaises(context.ContextError):
             list(m.parse_reactions())
 
@@ -265,7 +265,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
                 }]
             }
 
-        dmodel = native.NativeModel(dict_model)
+        dmodel = native.ModelReader(dict_model)
         self.assertEqual(dmodel.name, 'Test model')
         self.assertEqual(dmodel.biomass_reaction, 'rxn_1')
         self.assertEqual(dmodel.extracellular_compartment, 'e')
@@ -278,7 +278,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
             'default_flux_limit: 500'
         ]))
 
-        model = native.NativeModel.load_model_from_path(path)
+        model = native.ModelReader.reader_from_path(path)
 
         self.assertEqual(model.name, 'Test model')
         self.assertEqual(model.biomass_reaction, 'biomass_reaction_id')
@@ -287,11 +287,11 @@ class TestYAMLFileSystemData(unittest.TestCase):
 
     def test_bad_path(self):
         with self.assertRaises(native.ParseError):
-            native.NativeModel.load_model_from_path('/nope/nreal/path')
+            native.ModelReader.reader_from_path('/nope/nreal/path')
 
     def test_invalid_model_type(self):
         with self.assertRaises(ValueError):
-            native.NativeModel(42.2)
+            native.ModelReader(42.2)
 
     def test_parse_model_file_with_exchange(self):
         path = self.write_model_file('model.yaml', '\n'.join([
@@ -303,7 +303,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
             '      compartment: c'
         ]))
 
-        model = native.NativeModel.load_model_from_path(path)
+        model = native.ModelReader.reader_from_path(path)
 
         exchange = list(model.parse_exchange())
         self.assertEqual(exchange[0][0], Compound('A', 'Ex'))
@@ -320,7 +320,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
             '      compartment: c'
         ]))
 
-        model = native.NativeModel.load_model_from_path(path)
+        model = native.ModelReader.reader_from_path(path)
 
         exchange = list(model.parse_exchange())
         self.assertEqual(exchange[0][0], Compound('A', 'Ex'))
@@ -341,7 +341,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
             '    - id: D'
         ]))
 
-        model = native.NativeModel.load_model_from_path(path)
+        model = native.ModelReader.reader_from_path(path)
 
         with self.assertRaises(native.ParseError):
             medium = list(model.parse_exchange())

--- a/psamm/tests/test_gapfilling.py
+++ b/psamm/tests/test_gapfilling.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from psamm.datasource.native import NativeModel
+from psamm.datasource import native
 from psamm.metabolicmodel import MetabolicModel
 from psamm.database import DictDatabase
 from psamm.datasource.reaction import parse_reaction
@@ -67,7 +67,7 @@ class TestAddReactions(unittest.TestCase):
 
 class TestCreateExtendedModel(unittest.TestCase):
     def setUp(self):
-        self._model = NativeModel({
+        reader = native.ModelReader({
             'compartments': [
                 {
                     'id': 'c',
@@ -117,6 +117,7 @@ class TestCreateExtendedModel(unittest.TestCase):
                 ]
             }]
         })
+        self._model = reader.create_model()
 
     def test_create_model_extended(self):
         expected_reactions = set([

--- a/psamm/tests/test_randomsparse.py
+++ b/psamm/tests/test_randomsparse.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 # Copyright 2015  Keith Dufault-Thompson <keitht547@my.uri.edu>
 # Copyright 2016  Chao Liu <lcddzyx@gmail.com>
 
@@ -22,7 +22,7 @@ import unittest
 import tempfile
 import shutil
 
-from psamm.datasource.native import NativeModel
+from psamm.datasource.native import ModelReader
 from psamm.metabolicmodel import MetabolicModel
 from psamm.database import DictDatabase
 from psamm.datasource.reaction import parse_reaction
@@ -66,7 +66,8 @@ class TestGetGeneAssociation(unittest.TestCase):
                 '     - rxn_3',
                 '     - rxn_4',
             ]))
-        self._model = NativeModel.load_model_from_path(self._model_dir)
+        self._model = ModelReader.reader_from_path(
+            self._model_dir).create_model()
 
     def tearDown(self):
         shutil.rmtree(self._model_dir)


### PR DESCRIPTION
In `native`, change `NativeModel` so that it works as a store of model data in memory. The model parsing is moved to a new class `ModelReader` which can parse individual model sections (e.g. compounds, reactions) and also create a new `NativeModel` in-memory representation. The `NativeModel` is supplied to commands which means that commands no longer have to manually parse the model using `parse_X()` methods but can instead access the model entries directly.