### PR TITLE
tableexport: Quote problematic fields

### DIFF
--- a/psamm/commands/tableexport.py
+++ b/psamm/commands/tableexport.py
@@ -17,13 +17,31 @@
 
 from __future__ import unicode_literals
 
+import re
+import json
 import logging
 
-from six import text_type
+from six import text_type, string_types, integer_types
 
 from ..command import Command
 
 logger = logging.getLogger(__name__)
+
+
+_JSON_TYPES = string_types + integer_types + (
+    dict, list, tuple, float, bool, type(None))
+_QUOTE_REGEXP = re.compile(r'[\t\n]')
+
+
+def _encode_value(value):
+    if value is None:
+        return ''
+    if not isinstance(value, _JSON_TYPES):
+        value = text_type(value)
+    if (isinstance(value, string_types) and not _QUOTE_REGEXP.search(value) and
+            value != ''):
+        return value
+    return json.dumps(value)
 
 
 class ExportTableCommand(Command):
@@ -73,14 +91,12 @@ class ExportTableCommand(Command):
 
         model_reactions = set(self._model.parse_model())
         for reaction in self._model.parse_reactions():
-            line_content = [text_type(reaction.properties.get(property))
+            line_content = [reaction.properties.get(property)
                             for property in property_list_sorted]
-            if (not self._model.has_model_definition() or
-                    reaction.id in model_reactions):
-                line_content.append('True')
-            else:
-                line_content.append('False')
-            print('\t'.join(line_content))
+            in_model = (not self._model.has_model_definition() or
+                        reaction.id in model_reactions)
+            line_content.append(in_model)
+            print('\t'.join(_encode_value(value) for value in line_content))
 
     def _compound_export(self):
         compound_set = set()
@@ -96,14 +112,12 @@ class ExportTableCommand(Command):
         metabolic_model = self._model.create_metabolic_model()
         model_compounds = set(x.name for x in metabolic_model.compounds)
         for compound in self._model.parse_compounds():
-            line_content = [text_type(compound.properties.get(property))
+            line_content = [compound.properties.get(property)
                             for property in compound_list_sorted]
-            if (not self._model.has_model_definition() or
-                    compound.id in model_compounds):
-                line_content.append('True')
-            else:
-                line_content.append('False')
-            print('\t'.join(line_content))
+            in_model = (not self._model.has_model_definition() or
+                        compound.id in model_compounds)
+            line_content.append(in_model)
+            print('\t'.join(_encode_value(value) for value in line_content))
 
     def _media_export(self):
         print('{}\t{}\t{}\t{}'.format('Compound ID', 'Reaction ID',
@@ -117,15 +131,20 @@ class ExportTableCommand(Command):
             if upper is None:
                 upper = default_flux
 
-            print('{}\t{}\t{}\t{}'.format(compound, reaction, lower, upper))
+            print('\t'.join(_encode_value(value) for value in (
+                compound, reaction, lower, upper)))
 
     def _limits_export(self):
         print('{}\t{}\t{}'.format(
             'Reaction ID', 'Lower Limits', 'Upper Limits'))
         for reaction, lower, upper in self._model.parse_limits():
-            print('{}\t{}\t{}'.format(reaction, lower, upper))
+            print('\t'.join(_encode_value(value) for value in (
+                reaction, lower, upper)))
 
     def _metadata_export(self):
-        print('Model Name: {}'.format(self._model.name))
-        print('Biomass Reaction: {}'.format(self._model.biomass_reaction))
-        print('Default Flux Limits: {}'.format(self._model.default_flux_limit))
+        print('Model Name\t{}'.format(
+            _encode_value(self._model.name)))
+        print('Biomass Reaction\t{}'.format(
+            _encode_value(self._model.biomass_reaction)))
+        print('Default Flux Limits\t{}'.format(
+            _encode_value(self._model.default_flux_limit)))

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -282,11 +282,11 @@ class TestCommandMain(unittest.TestCase):
 
         self.assertEqual(f.getvalue(), '\n'.join('\t'.join(row) for row in [
             ['id', 'equation', 'genes', 'in_model'],
-            ['rxn_1', '|A_\u2206[e]| => |B[c]|', "['gene_1', 'gene_2']",
-             'True'],
+            ['rxn_1', '|A_\u2206[e]| => |B[c]|', '["gene_1", "gene_2"]',
+             'true'],
             ['rxn_2_\u03c0', '|B[c]| => |C[e]|',
-             'gene_3 or (gene_4 and gene_5)', 'True'],
-            ['rxn_3', '|D[c]| => |E[c]|', 'None', 'True'],
+             'gene_3 or (gene_4 and gene_5)', 'true'],
+            ['rxn_3', '|D[c]| => |E[c]|', '', 'true'],
             []
         ]))
 
@@ -296,7 +296,7 @@ class TestCommandMain(unittest.TestCase):
                 '--model', self._model_dir, 'tableexport', 'compounds'])
 
         self.assertEqual(f.getvalue(), '\n'.join([
-            'id\tin_model', 'A_\u2206\tTrue', 'B\tTrue', 'C\tTrue', ''
+            'id\tin_model', 'A_\u2206\ttrue', 'B\ttrue', 'C\ttrue', ''
         ]))
 
     def test_run_tableexport_medium(self):
@@ -306,8 +306,8 @@ class TestCommandMain(unittest.TestCase):
 
         self.assertEqual(f.getvalue(), '\n'.join([
             'Compound ID\tReaction ID\tLower Limit\tUpper Limit',
-            'A_\u2206[e]\tNone\t-1000\t1000',
-            'C[e]\tNone\t-1000\t1000',
+            'A_\u2206[e]\t\t-1000\t1000',
+            'C[e]\t\t-1000\t1000',
             ''
         ]))
 
@@ -318,7 +318,7 @@ class TestCommandMain(unittest.TestCase):
 
         self.assertEqual(f.getvalue(), '\n'.join([
             'Reaction ID\tLower Limits\tUpper Limits',
-            'rxn_2_\u03c0\tNone\t100',
+            'rxn_2_\u03c0\t\t100',
             ''
         ]))
 
@@ -328,9 +328,9 @@ class TestCommandMain(unittest.TestCase):
                 '--model', self._model_dir, 'tableexport', 'metadata'])
 
         self.assertEqual(f.getvalue(), '\n'.join([
-            'Model Name: Test model',
-            'Biomass Reaction: rxn_1',
-            'Default Flux Limits: 1000',
+            'Model Name\tTest model',
+            'Biomass Reaction\trxn_1',
+            'Default Flux Limits\t1000',
             ''
         ]))
 


### PR DESCRIPTION
Standardize table output fields in tableexport as JSON-except-mostly-unquoted-string. Strings are only quoted if they contain tabs or newlines.