### PR TITLE
Simplify tests for commands

### DIFF
--- a/psamm/command.py
+++ b/psamm/command.py
@@ -80,9 +80,10 @@ class Command(object):
             name = text_type(self._model.context)
         logger.info('Model: {}'.format(name))
 
-        version = util.git_try_describe(self._model.context.basepath)
-        if version is not None:
-            logger.info('Model Git version: {}'.format(version))
+        if self._model.context is not None:
+            version = util.git_try_describe(self._model.context.basepath)
+            if version is not None:
+                logger.info('Model Git version: {}'.format(version))
 
     @classmethod
     def init_parser(cls, parser):

--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -46,7 +46,10 @@ class ExcelExportCommand(Command):
             self.fail('Excel export requires the XlsxWriter python module')
         workbook = xlsxwriter.Workbook(self._args.file)
         reaction_sheet = workbook.add_worksheet(name='Reactions')
-        git_version = util.git_try_describe(self._model.context.basepath)
+
+        git_version = None
+        if self._model.context is not None:
+            git_version = util.git_try_describe(self._model.context.basepath)
 
         property_set = set()
         for reaction in model.parse_reactions():

--- a/psamm/commands/search.py
+++ b/psamm/commands/search.py
@@ -19,6 +19,8 @@ from __future__ import print_function, unicode_literals
 
 import re
 
+from six import text_type
+
 from ..command import Command, FilePrefixAppendAction
 from ..datasource.reaction import parse_compound
 
@@ -41,11 +43,11 @@ class SearchCommand(Command):
         parser_compound.set_defaults(which='compound')
         parser_compound.add_argument(
             '--id', '-i', dest='id', metavar='id',
-            action=FilePrefixAppendAction, type=str, default=[],
+            action=FilePrefixAppendAction, type=text_type, default=[],
             help='Compound ID')
         parser_compound.add_argument(
             '--name', '-n', dest='name', metavar='name',
-            action=FilePrefixAppendAction, type=str, default=[],
+            action=FilePrefixAppendAction, type=text_type, default=[],
             help='Name of compound')
 
         # Reaction subcommand

--- a/psamm/datasource/context.py
+++ b/psamm/datasource/context.py
@@ -71,7 +71,7 @@ class FilePathContext(object):
         return open(self.filepath, mode)
 
     def __str__(self):
-        return self._filepath
+        return text_type(self._filepath)
 
 
 @six.python_2_unicode_compatible

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -300,6 +300,7 @@ class NativeModel(object):
 
     @property
     def context(self):
+        """Model file loading context (or None, if undefined)."""
         return self._context
 
 

--- a/psamm/datasource/sbml.py
+++ b/psamm/datasource/sbml.py
@@ -817,7 +817,10 @@ class SBMLWriter(object):
         ET.register_namespace('mathml', MATHML_NS)
         ET.register_namespace('xhtml', XHTML_NS)
         ET.register_namespace('fbc', FBC_V2)
-        git_version = util.git_try_describe(model.context.basepath)
+
+        git_version = None
+        if model.context is not None:
+            git_version = util.git_try_describe(model.context.basepath)
 
         # Load compound information
         compound_name = {}

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 
 import sys
 import os
+import argparse
 import codecs
 import shutil
 import tempfile
@@ -31,6 +32,24 @@ from psamm.command import (main, Command, MetabolicMixin, SolverCommandMixin,
                            CommandError)
 from psamm.lpsolver import generic
 from psamm.datasource.native import NativeModel
+
+from psamm.commands.chargecheck import ChargeBalanceCommand
+from psamm.commands.excelexport import ExcelExportCommand
+from psamm.commands.fastgapfill import FastGapFillCommand
+from psamm.commands.fba import FluxBalanceCommand
+from psamm.commands.fluxcheck import FluxConsistencyCommand
+from psamm.commands.fluxcoupling import FluxCouplingCommand
+from psamm.commands.formulacheck import FormulaBalanceCommand
+from psamm.commands.fva import FluxVariabilityCommand
+from psamm.commands.gapcheck import GapCheckCommand
+from psamm.commands.gapfill import GapFillCommand
+from psamm.commands.genedelete import GeneDeletionCommand
+from psamm.commands.masscheck import MassConsistencyCommand
+from psamm.commands.randomsparse import RandomSparseNetworkCommand
+from psamm.commands.robustness import RobustnessCommand
+from psamm.commands.sbmlexport import SBMLExport
+from psamm.commands.search import SearchCommand
+from psamm.commands.tableexport import ExportTableCommand
 
 
 @contextmanager
@@ -87,40 +106,63 @@ class MockSolverCommand(SolverCommandMixin, Command):
 
 class TestCommandMain(unittest.TestCase):
     def setUp(self):
-        self._model_dir = tempfile.mkdtemp()
-        path = os.path.join(self._model_dir, 'model.yaml')
-        with codecs.open(path, 'w', 'utf-8') as f:
-            f.write('''---
-                name: Test model
-                biomass: rxn_1
-                reactions:
-                  - id: rxn_1
-                    equation: '|A_\u2206[e]| => |B[c]|'
-                    genes:
-                      - gene_1
-                      - gene_2
-                  - id: rxn_2_\u03c0
-                    equation: '|B[c]| => |C[e]|'
-                    genes: 'gene_3 or (gene_4 and gene_5)'
-                  - id: rxn_3
-                    equation: D[c] => E[c]
-                compounds:
-                  - id: A_\u2206
-                  - id: B
-                  - id: C
-                media:
-                  - compartment: e
-                    compounds:
-                      - id: A_\u2206
-                      - id: C
-                limits:
-                  - reaction: rxn_2_\u03c0
-                    upper: 100
-                ''')
-        self._model = NativeModel.load_model_from_path(self._model_dir)
+        self._model = NativeModel({
+            'name': 'Test model',
+            'biomass': 'rxn_1',
+            'reactions': [
+                {
+                    'id': 'rxn_1',
+                    'name': 'Reaction 1',
+                    'equation': '|A_\u2206[e]| => |B[c]|',
+                    'genes': ['gene_1', 'gene_2']
+                }, {
+                    'id': 'rxn_2_\u03c0',
+                    'name': 'Reaction 2',
+                    'equation': '|B[c]| <=> |C[e]|',
+                    'genes': 'gene_3 or (gene_4 and gene_5)'
+                }, {
+                    'id': 'rxn_3',
+                    'equation': 'D[c] => E[c]'
+                }
+            ],
+            'compounds': [
+                {
+                    'id': 'A_\u2206',
+                    'name': 'Compound A',
+                    'charge': 0
+                },
+                {
+                    'id': 'B',
+                    'name': 'Compound B',
+                    'formula': 'H2O',
+                    'charge': -1
+                },
+                {
+                    'id': 'C',
+                    'charge': -1,
+                    'formula': 'O2'
+                }
+            ],
+            'media': [
+                {
+                    'compartment': 'e',
+                    'compounds': [
+                        {'id': 'A_\u2206'},
+                        {'id': 'C'}
+                    ]
+                }
+            ],
+            'limits': [
+                {
+                    'reaction': 'rxn_2_\u03c0',
+                    'upper': 100
+                }
+            ]
+        })
 
-    def tearDown(self):
-        shutil.rmtree(self._model_dir)
+    def assertTableOutputEqual(self, output, table):
+        self.assertEqual(
+            output, '\n'.join('\t'.join(row) for row in table) + '\n')
 
     def is_solver_available(self, **kwargs):
         try:
@@ -130,13 +172,25 @@ class TestCommandMain(unittest.TestCase):
 
         return True
 
-    def run_solver_command(self, args, requirements):
+    def run_command(self, command_class, args=[], target=None):
+        parser = argparse.ArgumentParser()
+        command_class.init_parser(parser)
+        parsed_args = parser.parse_args(args)
+        command = command_class(self._model, parsed_args)
+
+        with redirected_stdout(target=target) as f:
+            command.run()
+
+        return f
+
+    def run_solver_command(
+            self, command_class, args=[], requirements={}, **kwargs):
         with redirected_stdout() as f:
             if self.is_solver_available(**requirements):
-                main(args=args)
+                self.run_command(command_class, args, **kwargs)
             else:
                 with self.assertRaises(generic.RequirementsError):
-                    main(args=args)
+                    self.run_command(command_class, args, **kwargs)
 
         return f
 
@@ -147,15 +201,16 @@ class TestCommandMain(unittest.TestCase):
             self.assertEqual(context.exception.code, 0)
 
     def test_run_chargecheck(self):
-        with redirected_stdout():
-            main(args=['--model', self._model_dir, 'chargecheck'])
+        self.run_command(ChargeBalanceCommand)
 
     def test_run_excelexport(self):
-        dest_path = os.path.join(self._model_dir, 'model.xlsx')
-        with redirected_stdout():
-            main(args=['--model', self._model_dir, 'excelexport', dest_path])
-
-        self.assertTrue(os.path.isfile(dest_path))
+        dest = tempfile.mkdtemp()
+        try:
+            dest_path = os.path.join(dest, 'model.xlsx')
+            self.run_command(ExcelExportCommand, [dest_path])
+            self.assertTrue(os.path.isfile(dest_path))
+        finally:
+            shutil.rmtree(dest)
 
     def test_run_fastgapfill(self):
         # Skip test if solver is GLPK because of issue #61.
@@ -166,190 +221,182 @@ class TestCommandMain(unittest.TestCase):
         except generic.RequirementsError:
             pass
 
-        self.run_solver_command([
-            '--model', self._model_dir, 'fastgapfill'], {})
+        self.run_solver_command(FastGapFillCommand)
 
     def test_run_fba(self):
-        self.run_solver_command(['--model', self._model_dir, 'fba'], {})
+        self.run_solver_command(FluxBalanceCommand)
+
+    def test_run_fba_show_all_reactions(self):
+        self.run_solver_command(FluxBalanceCommand, ['--all-reactions'])
 
     def test_run_fba_with_tfba(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fba', '--loop-removal', 'tfba'],
-            {'integer': True})
+        self.run_solver_command(
+            FluxBalanceCommand, ['--loop-removal', 'tfba'], {'integer': True})
 
     def test_run_fba_with_l1min(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fba', '--loop-removal', 'l1min'], {})
+        self.run_solver_command(
+            FluxBalanceCommand, ['--loop-removal', 'l1min'], {})
 
     def test_run_fluxcheck(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fluxcheck'], {})
+        self.run_solver_command(FluxConsistencyCommand)
+
+    def test_run_fluxcheck_with_unrestricted(self):
+        self.run_solver_command(FluxConsistencyCommand, ['--unrestricted'])
 
     def test_run_fluxcheck_with_fastcore(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fluxcheck', '--fastcore'], {})
+        self.run_solver_command(FluxConsistencyCommand, ['--fastcore'])
 
     def test_run_fluxcheck_with_tfba(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fluxcheck', '--loop-removal=tfba'],
-            {'integer': True})
+        self.run_solver_command(
+            FluxConsistencyCommand, ['--loop-removal=tfba'], {'integer': True})
 
     def test_run_fluxcheck_with_reduce_lp(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fluxcheck', '--reduce-lp'], {})
+        self.run_solver_command(FluxConsistencyCommand, ['--reduce-lp'])
 
     def test_run_fluxcheck_with_both_tfba_and_fastcore(self):
-        with self.assertRaises(SystemExit):
-            self.run_solver_command([
-                '--model', self._model_dir, 'fluxcheck',
-                '--loop-removal', '--fastcore'], {})
+        with self.assertRaises(CommandError):
+            self.run_solver_command(
+                FluxConsistencyCommand, ['--loop-removal=tfba', '--fastcore'],
+                {'integer': True})
 
     def test_run_fluxcoupling(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fluxcoupling'], {})
+        self.run_solver_command(FluxCouplingCommand)
 
     def test_run_formulacheck(self):
-        with redirected_stdout():
-            main(args=['--model', self._model_dir, 'formulacheck'])
+        self.run_command(FormulaBalanceCommand)
 
     def test_run_fva(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'fva'], {})
+        self.run_solver_command(FluxVariabilityCommand)
+
+    def test_run_fva_with_tfba(self):
+        self.run_solver_command(
+            FluxVariabilityCommand, ['--loop-removal=tfba'], {'integer': True})
 
     def test_run_gapcheck(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'gapcheck'], {'integer': True})
+        self.run_solver_command(
+            GapCheckCommand, requirements={'integer': True})
 
     def test_run_gapfill(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'gapfill'], {'integer': True})
+        self.run_solver_command(
+            GapFillCommand, requirements={'integer': True})
 
     def test_run_gapfill_with_blocked(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'gapfill', '--compound', 'D[c]'],
-            {'integer': True})
+        self.run_solver_command(
+            GapFillCommand, ['--compound', 'D[c]'], {'integer': True})
 
     def test_run_genedelete(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'genedelete', '--gene', 'gene_1'], {})
+        self.run_solver_command(GeneDeletionCommand, ['--gene', 'gene_1'])
 
     def test_run_masscheck_compounds(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'masscheck', '--type', 'compound'], {})
+        self.run_solver_command(MassConsistencyCommand, ['--type', 'compound'])
 
     def test_run_masscheck_reactions(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'masscheck', '--type', 'reaction'], {})
+        self.run_solver_command(MassConsistencyCommand, ['--type', 'reaction'])
+
+    def test_run_masscheck_reaction_with_checked(self):
+        self.run_solver_command(
+            MassConsistencyCommand, ['--type=reaction', '--checked=rxn_3'])
 
     def test_run_randomsparse_reactions(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'randomsparse', '--type=reactions',
-            '50%'], {})
+        self.run_solver_command(
+            RandomSparseNetworkCommand, ['--type=reactions', '50%'])
 
     def test_run_randomsparse_genes(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'randomsparse', '--type=genes', '50%'],
-            {})
+        self.run_solver_command(
+            RandomSparseNetworkCommand, ['--type=genes', '50%'])
 
     def test_run_randomsparse_exchange(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'randomsparse', '--type=exchange',
-            '50%'], {})
+        self.run_solver_command(
+            RandomSparseNetworkCommand, ['--type=exchange', '50%'])
 
     def test_run_robustness(self):
-        self.run_solver_command([
-            '--model', self._model_dir, 'robustness', 'rxn_2_\u03c0'], {})
+        self.run_solver_command(RobustnessCommand, ['rxn_2_\u03c0'])
+
+    def test_run_robustness_all_reactions(self):
+        self.run_solver_command(
+            RobustnessCommand, ['--all-reaction-fluxes', 'rxn_2_\u03c0'])
+
+    def test_run_robustness_with_tfba(self):
+        self.run_solver_command(
+            RobustnessCommand, ['--loop-removal=tfba', 'rxn_2_\u03c0'],
+            {'integer': True})
 
     def test_run_sbmlexport(self):
-        with redirected_stdout(BytesIO()):
-            main(args=['--model', self._model_dir, 'sbmlexport'])
+        self.run_command(SBMLExport, target=BytesIO())
 
     def test_run_search_compound(self):
-        with redirected_stdout():
-            main(args=[
-                '--model', self._model_dir, 'search', 'compound', '--id', 'A'])
+        self.run_command(SearchCommand, ['compound', '--id', 'A_\u2206'])
+
+    def test_run_search_compound_name(self):
+        self.run_command(SearchCommand, ['compound', '--name', 'Compound A'])
 
     def test_run_search_reaction(self):
-        with redirected_stdout():
-            main(args=[
-                '--model', self._model_dir, 'search', 'reaction',
-                '--id', 'rxn_1'])
+        self.run_command(SearchCommand, ['reaction', '--id', 'rxn_1'])
+
+    def test_run_search_reaction_by_compound(self):
+        self.run_command(SearchCommand, ['reaction', '--compound=A'])
 
     def test_run_tableexport_reactions(self):
-        with redirected_stdout() as f:
-            main(args=[
-                '--model', self._model_dir, 'tableexport', 'reactions'])
+        f = self.run_command(ExportTableCommand, ['reactions'])
 
-        self.assertEqual(f.getvalue(), '\n'.join('\t'.join(row) for row in [
-            ['id', 'equation', 'genes', 'in_model'],
+        self.assertTableOutputEqual(f.getvalue(), [
+            ['id', 'equation', 'genes', 'name', 'in_model'],
             ['rxn_1', '|A_\u2206[e]| => |B[c]|', '["gene_1", "gene_2"]',
-             'true'],
-            ['rxn_2_\u03c0', '|B[c]| => |C[e]|',
-             'gene_3 or (gene_4 and gene_5)', 'true'],
-            ['rxn_3', '|D[c]| => |E[c]|', '', 'true'],
-            []
-        ]))
+                'Reaction 1', 'true'],
+            ['rxn_2_\u03c0', '|B[c]| <=> |C[e]|',
+                'gene_3 or (gene_4 and gene_5)', 'Reaction 2', 'true'],
+            ['rxn_3', '|D[c]| => |E[c]|', '', '', 'true'],
+        ])
 
     def test_run_tableexport_compounds(self):
-        with redirected_stdout() as f:
-            main(args=[
-                '--model', self._model_dir, 'tableexport', 'compounds'])
+        f = self.run_command(ExportTableCommand, ['compounds'])
 
-        self.assertEqual(f.getvalue(), '\n'.join([
-            'id\tin_model', 'A_\u2206\ttrue', 'B\ttrue', 'C\ttrue', ''
-        ]))
+        self.assertTableOutputEqual(f.getvalue(), [
+            ['id', 'name', 'charge', 'formula', 'in_model'],
+            ['A_\u2206', 'Compound A', '0', '', 'true'],
+            ['B', 'Compound B', '-1', 'H2O', 'true'],
+            ['C', '', '-1', 'O2', 'true']
+        ])
 
     def test_run_tableexport_medium(self):
-        with redirected_stdout() as f:
-            main(args=[
-                '--model', self._model_dir, 'tableexport', 'medium'])
+        f = self.run_command(ExportTableCommand, ['medium'])
 
-        self.assertEqual(f.getvalue(), '\n'.join([
-            'Compound ID\tReaction ID\tLower Limit\tUpper Limit',
-            'A_\u2206[e]\t\t-1000\t1000',
-            'C[e]\t\t-1000\t1000',
-            ''
-        ]))
+        self.assertTableOutputEqual(f.getvalue(), [
+            ['Compound ID', 'Reaction ID', 'Lower Limit', 'Upper Limit'],
+            ['A_\u2206[e]', '', '-1000', '1000'],
+            ['C[e]', '', '-1000', '1000']
+        ])
 
     def test_run_tableexport_limits(self):
-        with redirected_stdout() as f:
-            main(args=[
-                '--model', self._model_dir, 'tableexport', 'limits'])
+        f = self.run_command(ExportTableCommand, ['limits'])
 
-        self.assertEqual(f.getvalue(), '\n'.join([
-            'Reaction ID\tLower Limits\tUpper Limits',
-            'rxn_2_\u03c0\t\t100',
-            ''
-        ]))
+        self.assertTableOutputEqual(f.getvalue(), [
+            ['Reaction ID', 'Lower Limits', 'Upper Limits'],
+            ['rxn_2_\u03c0', '', '100']
+        ])
 
     def test_run_tableexport_metadata(self):
-        with redirected_stdout() as f:
-            main(args=[
-                '--model', self._model_dir, 'tableexport', 'metadata'])
+        f = self.run_command(ExportTableCommand, ['metadata'])
 
-        self.assertEqual(f.getvalue(), '\n'.join([
-            'Model Name\tTest model',
-            'Biomass Reaction\trxn_1',
-            'Default Flux Limits\t1000',
-            ''
-        ]))
+        self.assertTableOutputEqual(f.getvalue(), [
+            ['Model Name', 'Test model'],
+            ['Biomass Reaction', 'rxn_1'],
+            ['Default Flux Limits', '1000']
+        ])
 
     def test_command_main(self):
-        main(MockCommand, args=[
-            '--model', self._model_dir, '--test-argument'])
+        self.run_command(MockCommand)
         self.assertTrue(MockCommand.run_called)
         self.assertTrue(MockCommand.init_parser_called)
         self.assertTrue(MockCommand.has_native_model)
 
     def test_solver_command_main(self):
         with self.assertRaises(generic.RequirementsError):
-            main(MockSolverCommand, args=[
-                '--model', self._model_dir,
-                '--solver', 'name=not-an-actual-solver'])
+            self.run_command(
+                MockSolverCommand, ['--solver', 'name=not-an-actual-solver'])
 
     def test_metabolic_command_main(self):
-        main(MockMetabolicCommand, args=[
-            '--model', self._model_dir])
+        self.run_command(MockMetabolicCommand)
         self.assertTrue(MockMetabolicCommand.has_metabolic_model)
 
     def test_command_fail(self):


### PR DESCRIPTION
Run tests directly using the `Command` and a `NativeModel` parsed from dict. This removes the step from all command tests that go through the `main()` function (this should be tested separately) and removes string parsing of `NativeModel`. The command tests are faster and more specific as a result.

First two commits fix various bugs uncovered by the change to the tests.