### PR TITLE
Added MOMA implementation into genedelete command

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -209,6 +209,53 @@ The file gene_file.txt would contain the following lines::
     ExGene1
     ExGene2
 
+To delete genes using different algorithms use ``--method`` to specify
+which algorithm for the solver to use. The default implementation for this
+command is FBA. The two examples below will yield the same result.
+
+.. code-block:: shell
+
+    $ psamm-model genedelete --gene ExGene1
+
+.. code-block:: shell
+
+    $ psamm-model genedelete --gene ExGene1 --method fba
+
+To delete genes using the Minimization of Metabolic Adjustment (MOMA)
+algorithm use the command line argument ``--method moma``.
+
+.. code-block:: shell
+
+    $ psamm-model genedelete --gene ExGene1 --method moma
+
+There are four implementations of MOMA inside of PSAMM:
+
+lin MOMA (``--method lin_moma``)
+  Finds the maximum biomass after a gene deletions, such that the change in
+  the flux system is minimized when compared to the wild type. Minimization
+  is done by minimizing the \|wild type fluxes - knockout fluxes|. This helps
+  avoid the assumption that an organism will perform optimally directly after
+  removing a gene.
+
+MOMA (``--method moma``) : Recommended
+  Finds the maximum biomass after a gene deletions, such that the change in
+  the flux system is minimized when compared to the wild type. Minimization
+  is done by minimizing the (wild type fluxes - knockout fluxes) :sup:`2` .
+  This helps avoid the assumption that an organism will perform optimally
+  directly after removing a gene.
+
+lin MOMA 2 (``--method lin_moma2``) : Experimental
+  Similar to ``lin_moma``, but this implementation solves for the wild type
+  fluxes at the same time as the knockout fluxes to ensure not to rely on the
+  arbitrary flux vector found with FBA. This will find a more optimal solution
+  to the problem than the original ``lin_moma``.
+
+MOMA 2 (``--method moma2``) : Experimental
+  Similar to ``moma``, but this implementation solves for the wild type
+  fluxes at the same time as the knockout fluxes to ensure not to rely on the
+  arbitrary flux vector found with FBA. This will find a more optimal solution
+  to the problem than the original ``moma``.
+
 Flux coupling analysis (``fluxcoupling``)
 -----------------------------------------
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -26,14 +26,14 @@ References
 .. [Muller13] Müller AC, Bockmayr A. Fast thermodynamically constrained flux
     variability analysis. Bioinformatics. 2013;29: 903–909.
     :doi:`10.1093/bioinformatics/btt059`.
-.. [Orth10] Orth JD, Thiele I, Palsson BØ. What is flux balance analysis? Nat
+.. [Orth10] Orth JD, Thiele I, Palsson Bo. What is flux balance analysis? Nat
     Biotechnol. Nature Publishing Group; 2010;28: 245–8.
     :doi:`10.1038/nbt.1614`.
 .. [Schilling00] Schilling CH, Letscher D, Palsson BO. Theory for the systemic
     definition of metabolic pathways and their use in interpreting metabolic
     function from a pathway-oriented perspective. J Theor Biol. 2000;203:
     229–48. :doi:`10.1006/jtbi.2000.1073`.
-.. [Segre02] Segrè D, Vitkup D, Church GM. Analysis of optimality in natural
+.. [Segre02] Segre D, Vitkup D, Church GM. Analysis of optimality in natural
     and perturbed metabolic networks. Proceedings of the National Academy of
     Sciences of the United States of America. 2002;99(23):15112-15117.
       :doi:`10.1073/pnas.232349399`.

--- a/psamm/lpsolver/lp.py
+++ b/psamm/lpsolver/lp.py
@@ -278,7 +278,7 @@ class Expression(object):
                 for v2, value2 in iteritems(other._variables):
                     p1 = v1 if isinstance(v1, Product) else Product((v1,))
                     p2 = v2 if isinstance(v2, Product) else Product((v2,))
-                    product = Product(sorted(p1 + p2, key=text_type))
+                    product = Product(sorted(p1 + p2, key=lambda p: id(p)))
                     variables[product] += value1 * value2
 
                 if other._offset != 0:
@@ -310,7 +310,7 @@ class Expression(object):
                 for v2, value2 in iteritems(other._variables):
                     p1 = v1 if isinstance(v1, Product) else Product((v1,))
                     p2 = v2 if isinstance(v2, Product) else Product((v2,))
-                    product = Product(sorted(p1 + p2, key=text_type))
+                    product = Product(sorted(p1 + p2, key=lambda p: id(p)))
                     variables[product] += value1 * value2
 
                 if other._offset != 0:
@@ -414,15 +414,11 @@ class Expression(object):
     def __str__(self):
         """Return string representation of expression"""
 
-        def sort_key_variable(item):
-            key, _ = item
-            is_product = isinstance(key, Product)
-            return is_product, text_type(key)
-
         def all_terms():
             count_vars = 0
             for name, value in sorted(
-                    iteritems(self._variables), key=sort_key_variable):
+                    iteritems(self._variables),
+                    key=lambda p: (isinstance(p[0], Product), p[0])):
                 if value != 0:
                     count_vars += 1
                     if isinstance(name, VariableSet):

--- a/psamm/moma.py
+++ b/psamm/moma.py
@@ -355,6 +355,25 @@ class MOMAProblem(object):
         with self.constraints(self._v_wt[objective] >= wt_obj):
             self._solve(lp.ObjectiveSense.Minimize)
 
+    def minimize_l2(self, objective):
+        wt_obj = self._solve_fba(objective)
+
+        obj_expr = 0
+        for reaction in self._adjustment_reactions():
+            v_wt = self._v_wt(reaction)
+            v = self._v(reaction)
+            obj_expr += (v_wt - v)**2
+
+        self._prob.set_objective(obj_expr)
+
+        v_wt_obj = self._v_wt(objective)
+        with self.constraints(v_wt_obj == wt_obj):
+            result = self._solve(lp.ObjectiveSense.Minimize)
+
+        if not result:
+            raise MOMAError('Unable to solve L2 MOMA: {}'.format(
+                result.status))
+
     def get_flux(self, reaction):
         """Return the knockout flux for a specific reaction."""
         return self._prob.result.get_value(self._v[reaction])

--- a/psamm/moma.py
+++ b/psamm/moma.py
@@ -52,7 +52,7 @@ class ConstraintGroup(object):
         self.delete()
 
     def add(self, *args):
-        """Add constraints to the model."""
+        """Add a constraints to the model."""
         self._constrs.extend(self._moma._prob.add_linear_constraints(*args))
 
     def delete(self):

--- a/psamm/moma.py
+++ b/psamm/moma.py
@@ -220,140 +220,55 @@ class MOMAProblem(object):
             fba_fluxes[key] = result.get_value(self._v_wt[key])
         return fba_fluxes
 
-    def get_fba_obj_flux(self, objective):
-        """Return the maximum objective flux solved by FBA."""
-        flux_result = self.solve_fba(objective)
-        return flux_result.get_value(self._v_wt[objective])
+    def minimize_qlp2(self, objective, wt_fluxes):
+        """Implemetnation of the MOMA algorithm.
 
-    def lin_moma(self, wt_fluxes):
-        """Minimize the redistribution of fluxes using a linear objective.
+        We try to maximize biomass, by keeping the fluxes relitively the same
+        as the wildtype. This helps avoid the assumption that an organism will
+        perform optimally directly after removing a gene.
 
-        The change in flux distribution is mimimized by minimizing the sum
-        of the absolute values of the differences of wild type FBA solution
-        and the knockout strain flux solution.
-
-        This formulation bases the solution on the wild type fluxes that
-        are specified by the user. If these wild type fluxes were calculated
-        using FBA, then an arbitrary flux vector that optimizes the objective
-        function is used. See [Segre`_02] for more information.
+        Minimizes sum of (wild type - knockout)^2
 
         Args:
-            wt_fluxes: Dictionary of all the wild type fluxes. Use
-                :meth:`.get_fba_flux(objective)` to return a dictionary of
-                fluxes found by FBA.
+            objective: Biomass reaction for the model.
+            wt_fluxes: All the wt_fluxes found by FBA in the form of a
+                dictionary. Use :meth: _get_fba_flux(objective) to return
+                a dictionary.
         """
+        # These are all of our non eachange reactions
         reactions = set(self._adjustment_reactions())
 
-        z_diff = self._z_diff
+        # Get the v model and all the reactions 'variables' associated with it
         v = self._v
 
-        with self.constraints() as constr:
-            for f_reaction, f_value in iteritems(wt_fluxes):
-                if f_reaction in reactions:
-                    # Add the constraint that finds the optimal solution, such
-                    # that the difference between the wildtype flux is similar
-                    # to the knockout flux.
-                    constr.add(
-                        z_diff[f_reaction] >= f_value - v[f_reaction],
-                        f_value - v[f_reaction] >= -z_diff[f_reaction])
-
-            # If we minimize the sum of the z vector then we will minimize
-            # the |vs_wt - vs| from above
-            self._prob.set_objective(z_diff.sum(reactions))
-
-            self._solve(lp.ObjectiveSense.Minimize)
-
-    def lin_moma2(self, objective, wt_obj):
-        """Find the smallest redistribution vector using a linear objective.
-
-        The change in flux distribution is mimimized by minimizing the sum
-        of the absolute values of the differences of wild type FBA solution
-        and the knockout strain flux solution.
-
-        Creates the constraint that the we select the optimal flux vector that
-        is closest to the wildtype. This might still return an arbitrary flux
-        vector the maximizes the objective function.
-
-        Args:
-            objective: Objective reaction for the model.
-            wt_obj: The flux value for your wild type objective reactions.
-                Can either use an expiremental value or on determined by FBA
-                by using :meth:`.get_fba_obj_flux(objective)`.
-        """
-        reactions = set(self._adjustment_reactions())
-
-        z_diff = self._z_diff
-        v = self._v
-        v_wt = self._v_wt
-
-        with self.constraints() as constr:
-            for f_reaction in reactions:
-                # Add the constraint that finds the optimal solution, such
-                # that the difference between the wildtype flux
-                # is similar to the knockout flux.
-                constr.add(
-                    z_diff[f_reaction] >= v_wt[f_reaction] - v[f_reaction],
-                    v_wt[f_reaction] - v[f_reaction] >= -z_diff[f_reaction])
-
-            # If we minimize the sum of the z vector then we will minimize
-            # the |v_wt - v| from above
-            self._prob.set_objective(z_diff.sum(reactions))
-
-            constr.add(self._v_wt[objective] >= wt_obj)
-
-            self._solve(lp.ObjectiveSense.Minimize)
-
-    def moma(self, wt_fluxes):
-        """Minimize the redistribution of fluxes using Euclidean distance.
-
-        Minimizing the redistribution of fluxes using a quadratic objective
-        function. The distance is minimized by minimizing the sum of
-        (wild type - knockout)^2.
-
-        Args:
-            wt_fluxes: Dictionary of all the wild type fluxes that will be
-                used to find a close MOMA solution. Fluxes can be expiremental
-                or calculated using :meth: get_fba_flux(objective).
-        """
-        reactions = set(self._adjustment_reactions())
-        v = self._v
+        # Create a constraints object for this model
+        constr = self.constraints()
 
         obj_expr = 0
+        # Loop through all the flux reactions
         for f_reaction, f_value in iteritems(wt_fluxes):
+            # Makes sure the reaction we are trying to put a constraint on is
+            # a non exchange reaction
             if f_reaction in reactions:
-                # Minimize the Euclidean distance between the two vectors
-                obj_expr += (f_value - v[f_reaction])**2
+                # Add the constraint that finds the optimal solution, such
+                # that the differenct between the wildtype flux
+                # is similar to the knockout flux.
+                obj_expr += (f_value - v(f_reaction))**2
 
-        self._prob.set_objective(obj_expr)
-        self._solve(lp.ObjectiveSense.Minimize)
-
-    def moma2(self, objective, wt_obj):
-        """Find the smallest redistribution vector using Euclidean distance.
-
-        Minimizing the redistribution of fluxes using a quadratic objective
-        function. The distance is minimized by minimizing the sum of
-        (wild type - knockout)^2.
-
-        Creates the constraint that the we select the optimal flux vector that
-        is closest to the wildtype. This might still return an arbitrary flux
-        vector the maximizes the objective function.
-
-        Args:
-            objective: Objective reaction for the model.
-            wt_obj: The flux value for your wild type objective reactions.
-                Can either use an expiremental value or on determined by FBA
-                by using :meth:`.get_fba_obj_flux(objective)`.
-        """
-        obj_expr = 0
-        for reaction in self._adjustment_reactions():
-            v_wt = self._v_wt[reaction]
-            v = self._v[reaction]
-            obj_expr += (v_wt - v)**2
-
+        # Set the objective
         self._prob.set_objective(obj_expr)
 
-        with self.constraints(self._v_wt[objective] >= wt_obj):
-            self._solve(lp.ObjectiveSense.Minimize)
+        # Minimize the squared distance between the wild type flux values and
+        # the knockout values
+        result = self._solve(lp.ObjectiveSense.Minimize)
+
+        # We need to go back and manually delete all the constaints
+        constr.delete()
+
+        # Need to make sure we catch any problems that occur in the solver
+        if not result:
+            raise MOMAError('Unable to solve QLP2 MOMA: {}'.format(
+                result.status))
 
     def minimize_l2(self, objective):
         wt_obj = self._solve_fba(objective)

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -441,6 +441,26 @@ class TestCommandMain(unittest.TestCase, BaseCommandTest):
     def test_run_genedelete(self):
         self.run_solver_command(GeneDeletionCommand, ['--gene', 'gene_1'])
 
+    def test_run_genedelete_with_fba(self):
+        self.run_solver_command(
+            GeneDeletionCommand, ['--gene=gene_1', '--method=fba'])
+
+    def test_run_genedelete_with_lin_moma(self):
+        self.run_solver_command(
+            GeneDeletionCommand, ['--gene=gene_1', '--method=lin_moma'])
+
+    def test_run_genedelete_with_lin_moma2(self):
+        self.run_solver_command(
+            GeneDeletionCommand, ['--gene=gene_1', '--method=lin_moma2'])
+
+    def test_run_genedelete_with_moma(self):
+        self.run_solver_command(
+            GeneDeletionCommand, ['--gene=gene_1', '--method=moma'], {'quadratic': True})
+
+    def test_run_genedelete_with_moma2(self):
+        self.run_solver_command(
+            GeneDeletionCommand, ['--gene=gene_1', '--method=moma2'], {'quadratic': True})
+
     def test_run_genedelete_with_infeasible(self):
         self.skip_test_if_no_solver()
         with self.assertRaises(SystemExit):

--- a/psamm/tests/test_lpsolver_lp.py
+++ b/psamm/tests/test_lpsolver_lp.py
@@ -18,6 +18,7 @@
 
 import math
 import unittest
+from six import iteritems
 
 from psamm.lpsolver import lp
 
@@ -190,20 +191,23 @@ class TestExpression(unittest.TestCase):
     def test_multiply_expression_and_simple_expression(self):
         e1 = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
         e2 = lp.Expression({'x1': 1})
-        e = e1 * e2
-        self.assertEqual(e.offset, 0)
-        self.assertEqual(dict(e.values()), {
+        e1 = e1 * e2
+        e2 = {
             lp.Product(['x1', 'x1']): -5,
             lp.Product(['x1', 'x2']): 3,
             'x1': 10
-        })
+        }
+
+        self.assertEqual(len(e1.values()), 3)
+        self.assertEqual(e1.offset, 0)
+        self.manual_assertEqual(e1,e2)
+
 
     def test_multiply_expression_and_expression(self):
         e1 = lp.Expression({'x1': 1, 'x2': 2, 'x3': 3}, offset=4)
         e2 = lp.Expression({'x2': 4, 'x4': 5}, offset=-5)
-        e = e1 * e2
-        self.assertEqual(e.offset, -20)
-        self.assertEqual(dict(e.values()), {
+        e1 = e1 * e2
+        e2 = {
             lp.Product(['x1', 'x2']): 4,
             lp.Product(['x2', 'x2']): 8,
             lp.Product(['x2', 'x3']): 12,
@@ -214,17 +218,24 @@ class TestExpression(unittest.TestCase):
             'x2': 6,
             'x3': -15,
             'x4': 20
-        })
+        }
+
+        self.assertEqual(len(e1.values()), 10)
+        self.assertEqual(e1.offset, -20)
+        self.manual_assertEqual(e1,e2)
 
     def test_multiply_expression_and_expression_in_place(self):
         e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
         e *= lp.Expression({'x1': 1})
-        self.assertEqual(e.offset, 0)
-        self.assertEqual(dict(e.values()), {
+        e1 = e
+        e2 = {
             lp.Product(['x1', 'x1']): -5,
             lp.Product(['x1', 'x2']): 3,
             'x1': 10
-        })
+        }
+        self.assertEqual(len(e1.values()), 3)
+        self.assertEqual(e.offset, 0)
+        self.manual_assertEqual(e1,e2)
 
     def test_expression_pow_negative(self):
         e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
@@ -264,20 +275,26 @@ class TestExpression(unittest.TestCase):
         e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
         e1 = e**2
         e2 = e*e
+        e2_values = dict(e2.values())
+
+        self.assertEqual(len(e1.values()), len(e2.values()))
         self.assertEqual(e1.offset, e2.offset)
-        self.assertEqual(dict(e1.values()), dict(e2.values()))
+        self.manual_assertEqual(e1,e2_values)
 
     def test_expression_pow_two_in_place(self):
         e = lp.Expression({'x1': -5, 'x2': 3}, offset=10)
-        e **= 2
-        self.assertEqual(e.offset, 100)
-        self.assertEqual(dict(e.values()), {
+        e1 = e**2
+
+        e2 = {
             lp.Product(['x1', 'x1']): 25,
             lp.Product(['x1', 'x2']): -30,
             lp.Product(['x2', 'x2']): 9,
             'x1': -100,
             'x2': 60
-        })
+        }
+        self.assertEqual(len(e1.values()), 5)
+        self.assertEqual(e1.offset, 100)
+        self.manual_assertEqual(e1,e2)
 
     def test_negate_expression(self):
         e = lp.Expression({'x1': 52}, -32)
@@ -306,6 +323,19 @@ class TestExpression(unittest.TestCase):
         e = lp.Expression({lp.Product(['x1', 'x1']): -1})
         self.assertIn(lp.Product(['x1', 'x1']), e)
         self.assertNotIn('x1', e)
+
+    def manual_assertEqual(self, e1, e2):
+        for key, value in iteritems(dict(e1.values())):
+            if key in e2:
+                self.assertEqual(value, e2[key])
+            else:
+                for key2, value2 in iteritems(e2):
+                    if sorted(key) == sorted(key2):
+                        self.assertEqual(value, value2)
+                        break
+                else:
+                    self.fail(
+                    'Key was not able to be found in the actual solution.')
 
 
 class TestRelation(unittest.TestCase):


### PR DESCRIPTION
Added the MOMA implementation into the genedelete command. Also, added tests and documentation for the genedelete command.

Had to fix expression multiplication error and had to rewrite the lp test functions that was effected.

FBA is still the default use of genedelete and the arg "--method moma" can be used to use MOMA.

There are 5 --method options:
- fba
- moma
- moma2
- lin_moma
- lin_moma2