### PR TITLE
Fix support for CPLEX 12.7

### DIFF
--- a/psamm/lpsolver/cplex.py
+++ b/psamm/lpsolver/cplex.py
@@ -323,12 +323,16 @@ class Problem(BaseProblem):
         # for QP/MIQP problems to avoid the warnings generated for other
         # problem types when this parameter is set.
         quad_obj = self._cp.objective.get_num_quadratic_variables() > 0
-        if quad_obj:
-            self._cp.parameters.solutiontarget.set(
-                self._cp.parameters.solutiontarget.values.optimal_global)
+
+        if hasattr(self._cp.parameters, 'optimalitytarget'):
+            target_param = self._cp.parameters.optimalitytarget
         else:
-            self._cp.parameters.solutiontarget.set(
-                self._cp.parameters.solutiontarget.values.auto)
+            target_param = self._cp.parameters.solutiontarget
+
+        if quad_obj:
+            target_param.set(target_param.values.optimal_global)
+        else:
+            target_param.set(target_param.values.auto)
 
     def _solve(self):
         self._reset_problem_type()

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     py27-{nosolver,cplex,qsoptex,gurobi,glpk},
     py33-{nosolver,qsoptex,glpk},
-    py34-{nosolver,cplex,qsoptex,glpk},
-    py35-{nosolver,qsoptex,glpk},
+    py34-{nosolver,qsoptex,glpk},
+    py35-{nosolver,cplex,qsoptex,glpk},
     py36-{nosolver,qsoptex,glpk},
     coverage,
     flake,
@@ -24,7 +24,7 @@ deps =
     coverage~=4.0
     xlsxwriter
     py27-cplex: {env:CPLEX_PYTHON2_PACKAGE}
-    py34-cplex: {env:CPLEX_PYTHON3_PACKAGE}
+    py35-cplex: {env:CPLEX_PYTHON3_PACKAGE}
     qsoptex: python-qsoptex>=0.5
     gurobi: {env:GUROBI_PYTHON_PACKAGE}
     glpk: swiglpk==1.2.13


### PR DESCRIPTION
The parameter `solutiontarget` has been deprecated. The new name for this parameter is `optimalitytarget`.

Tox now runs tests on CPLEX with Python 3.5 since that is the only Python 3 version that is supported by CPLEX 12.7.