### PR TITLE
Support Python 3.5/3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 cache:
     directories:
@@ -30,12 +31,32 @@ install:
 
 script: tox -v
 after_success: coveralls
-env:
-    - TOXENV=py27-nosolver,py34-nosolver,coverage
-    - TOXENV=py27-qsoptex,py34-qsoptex,coverage
-    - TOXENV=py27-glpk,py34-glpk,coverage
-    - TOXENV=docs
-    - TOXENV=flake
+matrix:
+    include:
+        - env: TOXENV=flake
+
+        - env: TOXENV=py27-nosolver,coverage
+          python: '2.7'
+        - env: TOXENV=py27-glpk,coverage
+          python: '2.7'
+        - env: TOXENV=py27-qsoptex,coverage
+          python: '2.7'
+
+        - env: TOXENV=py35-nosolver,coverage
+          python: '3.5'
+        - env: TOXENV=py35-glpk,coverage
+          python: '3.5'
+        - env: TOXENV=py35-qsoptex,coverage
+          python: '3.5'
+
+        - env: TOXENV=py36-nosolver,coverage
+          python: '3.6'
+        - env: TOXENV=py36-glpk,coverage
+          python: '3.6'
+        - env: TOXENV=py36-qsoptex,coverage
+          python: '3.6'
+
+        - env: TOXENV=docs
 
 deploy:
     provider: pypi

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
     ],
 
     packages=find_packages(),

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist =
     py27-{nosolver,cplex,qsoptex,gurobi,glpk},
     py33-{nosolver,qsoptex,glpk},
     py34-{nosolver,cplex,qsoptex,glpk},
+    py35-{nosolver,qsoptex,glpk},
+    py36-{nosolver,qsoptex,glpk},
     coverage,
     flake,
     docs


### PR DESCRIPTION
Run tests with Python 3.5/3.6 and mark these versions as supported in `setup.py`.