### PR TITLE
Fixed --help newline styling

### DIFF
--- a/psamm/command.py
+++ b/psamm/command.py
@@ -516,6 +516,7 @@ def main(command_class=None, args=None):
             title, _, _ = command_class.__doc__.partition('\n\n')
             subparser = subparsers.add_parser(
                 name, help=title.rstrip('.'),
+                formatter_class=argparse.RawDescriptionHelpFormatter,
                 description=command_class.__doc__)
             subparser.set_defaults(command=command_class)
             command_class.init_parser(subparser)

--- a/psamm/command.py
+++ b/psamm/command.py
@@ -459,6 +459,34 @@ class SequentialExecutor(Executor):
         pass
 
 
+def _trim(docstring):
+    """Return a trimmed docstring.
+
+    Code taken from 'PEP 257 -- Docstring Conventions' article.
+    """
+    if not docstring:
+        return ''
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = len(line) - len(stripped)
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    for line in lines[1:]:
+        trimmed.append(line[indent:].rstrip())
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+    # Return a single string:
+    return '\n'.join(trimmed)
+
+
 def main(command_class=None, args=None):
     """Run the command line interface with the given :class:`Command`.
 
@@ -517,7 +545,7 @@ def main(command_class=None, args=None):
             subparser = subparsers.add_parser(
                 name, help=title.rstrip('.'),
                 formatter_class=argparse.RawDescriptionHelpFormatter,
-                description=command_class.__doc__)
+                description=_trim(command_class.__doc__))
             subparser.set_defaults(command=command_class)
             command_class.init_parser(subparser)
 


### PR DESCRIPTION
When running a command with the --help option, the description of the command is shown. This description is based on the docstring of the Command subclass representing the running command. However, the formatting of the original docstring is not preserved. For example, the tableexport command contains a docstring with a list formatted with bullet points indentation and whitespace. In the output all newlines are converted to single spaces. The output should use the original formatting insert.

Fixed the problem by using RawDescriptionHelpFormatter as formatter_class. Description of the argument is below.

> Passing RawDescriptionHelpFormatter as formatter_class= indicates that description and epilog are already correctly formatted and should not be line-wrapped:

Documentation: [docs.python.org](https://docs.python.org/3/library/argparse.html#formatter-class) 
