### PR TITLE
Allow compartments to be specified in model.yaml

### DIFF
--- a/docs/file_format.rst
+++ b/docs/file_format.rst
@@ -12,16 +12,30 @@ used as a template:
     name: Escherichia coli test model
     biomass: Biomass
     extracellular: e
+
+    compartments:
+      - id: e
+        name: Extracellular
+      - id: p
+        name: Periplasm
+        adjacent_to: [e, c]
+      - id: c
+        name: Cytosol
+        adjacent_to: p
+
     compounds:
       - include: ../path/to/ModelSEED_cpds.tsv
         format: modelseed
+
     reactions:
       - include: reactions/reactions.tsv
       - include: reactions/biomass.yaml
+
     media:
       - include: medium.yaml
     limits:
       - include: limits.yaml
+
     model:
       - include: model_def.tsv
 
@@ -47,6 +61,17 @@ compartment.  For example, the reaction ``|x[e]| + |atp| => |x| + |adp| + |pi|``
 does not specify a compartment on four of the compounds so those four would
 automatically be presumed to be in the default compartment (or ``c`` if no default
 compartment is specified).
+
+Compartments
+------------
+
+The ``compartments`` key is a list of compartment information for the model.
+Compartments must always have an ``id`` but can also have additional user
+defined properties. The ``adjacent_to`` property is used to define the
+boundaries between compartments. Notice that the adjacency can be specified as
+a single compartment or a list of compartments. Note that it is sufficient to
+specify that ``p`` is adjacent to ``e``. It is then inferred that ``e`` is
+adjacent to ``p`` so it is optional to specify both directions of adjacency.
 
 Compounds
 ---------

--- a/psamm/datasource/entry.py
+++ b/psamm/datasource/entry.py
@@ -18,6 +18,7 @@
 """Representation of compound/reaction entries in models."""
 
 import abc
+from collections import Mapping
 
 from six import add_metaclass
 
@@ -84,11 +85,13 @@ class _BaseDictEntry(ModelEntry):
             self._properties = dict(properties.properties)
             if filemark is None:
                 filemark = properties.filemark
-        else:
+        elif isinstance(properties, Mapping):
             if 'id' not in properties:
                 raise ValueError('id not defined in properties')
             self._id = properties['id']
             self._properties = dict(properties)
+        else:
+            raise ValueError('Invalid type of properties object')
 
         self._filemark = filemark
 

--- a/psamm/datasource/entry.py
+++ b/psamm/datasource/entry.py
@@ -72,6 +72,10 @@ class ReactionEntry(ModelEntry):
         return self.properties.get('genes')
 
 
+class CompartmentEntry(ModelEntry):
+    """Abstract compartment entry."""
+
+
 class _BaseDictEntry(ModelEntry):
     """Base class for concrete entries based on dictionary."""
     def __init__(self, abstract_type, properties={}, filemark=None):
@@ -105,7 +109,7 @@ class DictCompoundEntry(CompoundEntry, _BaseDictEntry):
     """Compound entry backed by dictionary.
 
     The given properties dictionary must contain a key 'id' with the
-    identified.
+    identifier.
 
     Args:
         properties: dict or :class:`CompoundEntry` to construct from.
@@ -119,7 +123,7 @@ class DictReactionEntry(ReactionEntry, _BaseDictEntry):
     """Reaction entry backed by dictionary.
 
     The given properties dictionary must contain a key 'id' with the
-    identified.
+    identifier.
 
     Args:
         properties: dict or :class:`ReactionEntry` to construct from.
@@ -127,3 +131,18 @@ class DictReactionEntry(ReactionEntry, _BaseDictEntry):
     """
     def __init__(self, *args, **kwargs):
         super(DictReactionEntry, self).__init__(ReactionEntry, *args, **kwargs)
+
+
+class DictCompartmentEntry(CompartmentEntry, _BaseDictEntry):
+    """Compartment entry backed by dictionary.
+
+    The given properties dictionary must contain a key 'id' with the
+    identifier.
+
+    Args:
+        properties: dict or :class:`CompartmentEntry` to construct from.
+        filemark: Where the entry was parsed from (optional)
+    """
+    def __init__(self, *args, **kwargs):
+        super(DictCompartmentEntry, self).__init__(
+            CompartmentEntry, *args, **kwargs)

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -301,11 +301,18 @@ class NativeModel(object):
             if reaction.equation is not None:
                 database.set_reaction(reaction.id, reaction.equation)
 
+        # Warn about undefined compartments
+        compartments = set()
+        compartments_iter, boundaries = self.parse_compartments()
+        for compartment in compartments_iter:
+            compartments.add(compartment.id)
+
         # Warn about undefined compounds
         compounds = set()
         for compound in self.parse_compounds():
             compounds.add(compound.id)
 
+        undefined_compartments = set()
         undefined_compounds = set()
         extracellular_compounds = set()
         extracellular = self.extracellular_compartment
@@ -315,6 +322,13 @@ class NativeModel(object):
                     undefined_compounds.add(compound.name)
                 if compound.compartment == extracellular:
                     extracellular_compounds.add(compound.name)
+                if compound.compartment not in compartments:
+                    undefined_compartments.add(compound.compartment)
+
+        for compartment in sorted(undefined_compartments):
+            logger.warning(
+                'The compartment {} was not defined in the list'
+                ' of compartments'.format(compartment))
 
         for compound in sorted(undefined_compounds):
             logger.warning(

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -33,7 +33,7 @@ import math
 from collections import OrderedDict
 
 import yaml
-from six import string_types, text_type, iteritems, PY3
+from six import string_types, text_type, iteritems, itervalues, PY3
 from decimal import Decimal
 
 from ..reaction import Reaction, Compound, Direction
@@ -43,7 +43,8 @@ from ..metabolicmodel import MetabolicModel
 from ..database import DictDatabase
 from .context import FilePathContext, FileMark
 from .entry import (DictCompoundEntry as CompoundEntry,
-                    DictReactionEntry as ReactionEntry)
+                    DictReactionEntry as ReactionEntry,
+                    DictCompartmentEntry as CompartmentEntry)
 from .reaction import ReactionParser
 from . import modelseed
 
@@ -148,6 +149,50 @@ class NativeModel(object):
         # No model could be loaded
         raise ParseError('No model file could be found ({})'.format(
             ', '.join(DEFAULT_MODEL)))
+
+    def parse_compartments(self):
+        """Parse compartment information from model.
+
+        Return tuple of: 1) iterator of :class:`.CompartmentEntry`; 2)
+        Set of pairs defining the compartment boundaries of the model.
+        """
+
+        compartments = OrderedDict()
+        boundaries = set()
+
+        if 'compartments' in self._model:
+            boundary_map = {}
+            for compartment_def in self._model['compartments']:
+                compartment_id = compartment_def.get('id')
+                _check_id(compartment_id, 'Compartment')
+                if compartment_id in compartments:
+                    raise ParseError('Duplicate compartment ID: {}'.format(
+                        compartment_id))
+
+                props = dict(compartment_def)
+                adjacent_to = props.pop('adjacent_to', None)
+                if adjacent_to is not None:
+                    if not isinstance(adjacent_to, list):
+                        adjacent_to = [adjacent_to]
+                    for other in adjacent_to:
+                        boundary_map.setdefault(other, set()).add(
+                            compartment_id)
+
+                mark = FileMark(self._context, None, None)
+                compartment = CompartmentEntry(props, mark)
+                compartments[compartment_id] = compartment
+
+            # Check boundaries from boundary_map
+            for source, dest_set in iteritems(boundary_map):
+                if source not in compartments:
+                    raise ParseError(
+                        'Invalid compartment {} referenced'
+                        ' by compartment {}'.format(
+                            source, ', '.join(dest_set)))
+                for dest in dest_set:
+                    boundaries.add(tuple(sorted((source, dest))))
+
+        return itervalues(compartments), frozenset(boundaries)
 
     @property
     def name(self):

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -109,6 +109,18 @@ class TestCommandMain(unittest.TestCase):
         self._model = NativeModel({
             'name': 'Test model',
             'biomass': 'rxn_1',
+            'compartments': [
+                {
+                    'id': 'e',
+                    'name': 'Extracellular',
+                    'adjacent_to': ['c']
+                },
+                {
+                    'id': 'c',
+                    'name': 'Cytosol',
+                    'adjacent_to': 'e'
+                }
+            ],
             'reactions': [
                 {
                     'id': 'rxn_1',

--- a/psamm/tests/test_datasource_entry.py
+++ b/psamm/tests/test_datasource_entry.py
@@ -1,0 +1,85 @@
+# This file is part of PSAMM.
+#
+# PSAMM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PSAMM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
+
+import unittest
+
+from psamm.datasource import entry
+
+
+class TestDictEntries(unittest.TestCase):
+    def test_create_compound_dict_entry(self):
+        props = {
+            'id': 'test_compound',
+            'name': 'Test compound',
+            'formula': 'H2O',
+            'charge': 1,
+            'custom': 'ABC'
+        }
+        e = entry.DictCompoundEntry(props)
+        self.assertIsInstance(e, entry.CompoundEntry)
+        self.assertEqual(e.id, 'test_compound')
+        self.assertEqual(e.name, 'Test compound')
+        self.assertEqual(e.formula, 'H2O')
+        self.assertEqual(e.charge, 1)
+        self.assertEqual(e.properties.get('custom'), 'ABC')
+
+    def test_create_compound_dict_entry_copy(self):
+        props = {
+            'id': 'test_compound',
+            'name': 'Test compound'
+        }
+        e = entry.DictCompoundEntry(props)
+        e2 = entry.DictCompoundEntry(e)
+        self.assertIsInstance(e2, entry.CompoundEntry)
+        self.assertEqual(e2.id, 'test_compound')
+        self.assertEqual(e2.name, 'Test compound')
+
+    def test_create_compound_dict_entry_without_id(self):
+        props = {
+            'name': 'Compound 1',
+            'formula': 'CO2'
+        }
+        with self.assertRaises(ValueError):
+            e = entry.DictCompoundEntry(props)
+
+    def test_create_reaction_entry(self):
+        props = {
+            'id': 'reaction_1',
+            'name': 'Reaction 1'
+        }
+        e = entry.DictReactionEntry(props)
+        self.assertIsInstance(e, entry.ReactionEntry)
+        self.assertEqual(e.id, 'reaction_1')
+        self.assertEqual(e.name, 'Reaction 1')
+
+    def test_create_reaction_entry_from_compound_entry(self):
+        e = entry.DictCompoundEntry({
+            'id': 'compound_1',
+            'name': 'Compound 1'
+        })
+        with self.assertRaises(ValueError):
+            e2 = entry.DictReactionEntry(e)
+
+    def test_create_compartment_entry(self):
+        props = {
+            'id': 'c',
+            'name': 'Cytosol'
+        }
+        e = entry.DictCompartmentEntry(props)
+        self.assertIsInstance(e, entry.CompartmentEntry)
+        self.assertEqual(e.id, 'c')
+        self.assertEqual(e.name, 'Cytosol')

--- a/psamm/tests/test_datasource_native.py
+++ b/psamm/tests/test_datasource_native.py
@@ -33,6 +33,52 @@ import yaml
 
 
 class TestYAMLDataSource(unittest.TestCase):
+    def test_parse_compartments(self):
+        model_dict = {
+            'compartments': [
+                {
+                    'id': 'e',
+                    'name': 'Extracellular'
+                },
+                {
+                    'id': 'p',
+                    'name': 'Periplasm',
+                    'adjacent_to': ['e', 'c']
+                },
+                {
+                    'id': 'c',
+                    'name': 'Cytosol',
+                    'adjacent_to': 'p'
+                },
+                {
+                    'id': 'internal',
+                    'name': 'Internal compartment',
+                    'adjacent_to': 'c'
+                }
+            ]
+        }
+        model = native.NativeModel(model_dict)
+        compartment_iter, boundaries = model.parse_compartments()
+        compartments = list(compartment_iter)
+
+        self.assertEqual(len(compartments), 4)
+        self.assertEqual(compartments[0].id, 'e')
+        self.assertEqual(compartments[0].name, 'Extracellular')
+        self.assertEqual(compartments[1].id, 'p')
+        self.assertEqual(compartments[1].name, 'Periplasm')
+        self.assertEqual(compartments[2].id, 'c')
+        self.assertEqual(compartments[2].name, 'Cytosol')
+        self.assertEqual(compartments[3].id, 'internal')
+        self.assertEqual(compartments[3].name, 'Internal compartment')
+
+        normalized_boundaries = set(
+            tuple(sorted((c1, c2))) for c1, c2 in boundaries)
+        self.assertSetEqual(normalized_boundaries, {
+            ('c', 'internal'),
+            ('c', 'p'),
+            ('e', 'p')
+        })
+
     def test_parse_reaction(self):
         reaction = native.parse_reaction({
             'id': 'reaction_123',


### PR DESCRIPTION
Compartments are specified in `model.yaml`, for example:

``` yaml
name: Example model
biomass: Biomass_reaction
compartments:
  - id: p
    name: Periplasm
    adjacent_to: [c, e]
  - id: c
    name: Cytosol
    adjacent_to: p
  - id: e
    name: Extracellular space
compounds:
  # ...
```

Notice that the adjacency can be specified as a single compartment or a list of compartments. Note that it is sufficient to specify that `p` is adjacent to `e`. It is then inferred that `e` is adjacent to `p` so it is optional to specify both directions of adjacency.

The compartment information is parsed and represented as `CompartmentEntry` in `NativeModel`. The compartment boundaries are also made available by `NativeModel` and will be used to create correct transport reactions for gap-filling in another pull request.