### PR TITLE
Add missing API documentation

### DIFF
--- a/docs/api/datasource_context.rst
+++ b/docs/api/datasource_context.rst
@@ -1,0 +1,6 @@
+
+``psamm.datasource.context`` -- File system contexts
+====================================================
+
+.. automodule:: psamm.datasource.context
+   :members:

--- a/docs/api/datasource_entry.rst
+++ b/docs/api/datasource_entry.rst
@@ -1,0 +1,6 @@
+
+``psamm.datasource.entry`` -- Model entry representations
+=========================================================
+
+.. automodule:: psamm.datasource.entry
+   :members:

--- a/docs/api/lpsolver_cplex.rst
+++ b/docs/api/lpsolver_cplex.rst
@@ -1,5 +1,5 @@
 
-``psamm.lpsolver.cplex`` -- Cplex LP solver
+``psamm.lpsolver.cplex`` -- CPLEX LP solver
 ============================================
 
 .. automodule:: psamm.lpsolver.cplex

--- a/docs/api/lpsolver_glpk.rst
+++ b/docs/api/lpsolver_glpk.rst
@@ -1,0 +1,6 @@
+
+``psamm.lpsolver.glpk`` -- GLPK LP solver
+============================================
+
+.. automodule:: psamm.lpsolver.glpk
+   :members:

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -1,0 +1,6 @@
+
+``psamm.util`` -- Internal utilities
+====================================
+
+.. automodule:: psamm.util
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ sys.path.insert(0, os.path.abspath('extensions'))
 
 # Mock optional modules to allow autodoc to run even in the absense of these
 # modules.
-MOCK_MODULES = ['cplex', 'qsoptex', 'gurobipy']
+MOCK_MODULES = ['cplex', 'gurobipy', 'qsoptex', 'swiglpk']
 for module in MOCK_MODULES:
     sys.modules[module] = mock.Mock()
 

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -57,7 +57,7 @@ class GLPKError(Exception):
 
 
 class Solver(BaseSolver):
-    """Represents an LP-solver using Gurobi."""
+    """Represents an LP-solver using GLPK."""
 
     def __init__(self):
         super(Solver, self).__init__()
@@ -69,7 +69,7 @@ class Solver(BaseSolver):
 
 
 class Problem(BaseProblem):
-    """Represents an LP-problem of a gurobi.Solver."""
+    """Represents an LP-problem of a :class:`.Solver`."""
 
     VARTYPE_MAP = {
         VariableType.Continuous: swiglpk.GLP_CV,
@@ -345,7 +345,7 @@ class Problem(BaseProblem):
 
 
 class Constraint(BaseConstraint):
-    """Represents a constraint in a gurobi.Problem."""
+    """Represents a constraint in a :class:`.Problem`."""
 
     def __init__(self, prob, name):
         self._prob = prob
@@ -358,11 +358,11 @@ class Constraint(BaseConstraint):
 
 
 class Result(BaseResult):
-    """Represents the solution to a gurobi.Problem.
+    """Represents the solution to a :class:`.Problem`.
 
-    This object will be returned from the gurobi.Problem.solve() method or by
-    accessing the gurobi.Problem.result property after solving a problem. This
-    class should not be instantiated manually.
+    This object will be returned from the solve() method on :class:`.Problem`
+    or by accessing the result property on :class:`.Problem` after solving a
+    problem. This class should not be instantiated manually.
 
     Result will evaluate to a boolean according to the success of the
     solution, so checking the truth value of the result will immediately


### PR DESCRIPTION
Adds entries for modules in the API documentation that were previously left out.

Some fixes were applied to docstrings in the `glpk` module where the docstrings erroneously referred to `gurobi`.