### PR TITLE
Use compartment information when gap-filling

### DIFF
--- a/psamm/datasource/context.py
+++ b/psamm/datasource/context.py
@@ -47,7 +47,11 @@ class FilePathContext(object):
                 self._filepath = arg
             else:
                 self._filepath = arg.filepath
-            self._basepath = os.path.dirname(self._filepath)
+
+            if self._filepath is not None:
+                self._basepath = os.path.dirname(self._filepath)
+            else:
+                self._basepath = None
         else:
             self._filepath = None
             self._basepath = None

--- a/psamm/fastgapfill.py
+++ b/psamm/fastgapfill.py
@@ -55,13 +55,15 @@ def create_extended_model(model, db_penalty=None, ex_penalty=None,
     model_compartments = set(model_extended.compartments)
     extra_compartments = model.extracellular_compartment
 
+    _, boundaries = model.parse_compartments()
+
     # Add exchange and transport reactions to database
     logger.info('Adding database, exchange and transport reactions')
     db_added = model_extended.add_all_database_reactions(model_compartments)
     ex_added = model_extended.add_all_exchange_reactions(
         extra_compartments, allow_duplicates=True)
     tp_added = model_extended.add_all_transport_reactions(
-        extra_compartments, allow_duplicates=True)
+        boundaries, allow_duplicates=True)
 
     # Add penalty weights on reactions
     weights = {}

--- a/psamm/fastgapfill.py
+++ b/psamm/fastgapfill.py
@@ -52,18 +52,44 @@ def create_extended_model(model, db_penalty=None, ex_penalty=None,
 
     # Create metabolic model
     model_extended = model.create_metabolic_model()
-    model_compartments = set(model_extended.compartments)
-    extra_compartments = model.extracellular_compartment
+    extra_compartment = model.extracellular_compartment
+    compartments, boundaries = model.parse_compartments()
 
-    _, boundaries = model.parse_compartments()
+    compartment_ids = set(c.id for c in compartments)
 
-    # Add exchange and transport reactions to database
-    logger.info('Adding database, exchange and transport reactions')
-    db_added = model_extended.add_all_database_reactions(model_compartments)
+    # Add database reactions to extended model
+    if len(compartment_ids) > 0:
+        logger.info(
+            'Using all database reactions in compartments: {}...'.format(
+                ', '.join('{}'.format(c) for c in compartment_ids)))
+        db_added = model_extended.add_all_database_reactions(compartment_ids)
+    else:
+        logger.warning(
+            'No compartments specified in the model; database reactions will'
+            ' not be used! Add compartment specification to model to include'
+            ' database reactions for those compartments.')
+        db_added = set()
+
+    # Add exchange reactions to extended model
+    logger.info(
+        'Using artificial exchange reactions for compartment: {}...'.format(
+            extra_compartment))
     ex_added = model_extended.add_all_exchange_reactions(
-        extra_compartments, allow_duplicates=True)
-    tp_added = model_extended.add_all_transport_reactions(
-        boundaries, allow_duplicates=True)
+        extra_compartment, allow_duplicates=True)
+
+    # Add transport reactions to extended model
+    if len(boundaries) > 0:
+        logger.info(
+            'Using artificial transport reactions for the compartment'
+            ' boundaries: {}...'.format(
+                '; '.join('{}<->{}'.format(c1, c2) for c1, c2 in boundaries)))
+        tp_added = model_extended.add_all_transport_reactions(
+            boundaries, allow_duplicates=True)
+    else:
+        logger.warning(
+            'No compartment boundaries specified in the model;'
+            ' artificial transport reactions will not be used!')
+        tp_added = set()
 
     # Add penalty weights on reactions
     weights = {}

--- a/psamm/metabolicmodel.py
+++ b/psamm/metabolicmodel.py
@@ -282,12 +282,15 @@ class MetabolicModel(MetabolicDatabase):
                 all_reactions[rx] = rxnid
 
         added = set()
-        for compound in sorted(self.compounds):
+        initial_compounds = set(self.compounds)
+        for model_compound in initial_compounds:
+            compound = model_compound.in_compartment(compartment)
             rxnid_ex = ('rxnex', compound)
+            if rxnid_ex in added:
+                continue
+
             if not self._database.has_reaction(rxnid_ex):
-                reaction_ex = Reaction(Direction.Both, {
-                    compound.in_compartment(compartment): -1
-                })
+                reaction_ex = Reaction(Direction.Both, {compound: -1})
                 if reaction_ex not in all_reactions:
                     self._database.set_reaction(rxnid_ex, reaction_ex)
                 else:

--- a/psamm/tests/test_fastgapfill.py
+++ b/psamm/tests/test_fastgapfill.py
@@ -78,8 +78,8 @@ class TestCreateExtendedModel(unittest.TestCase):
             ('rxntp', Compound('B', 'c')),
             ('rxntp', Compound('C', 'c')),
             ('rxnex', Compound('A', 'e')),
-            ('rxnex', Compound('B', 'c')),
-            ('rxnex', Compound('C', 'c')),
+            ('rxnex', Compound('B', 'e')),
+            ('rxnex', Compound('C', 'e')),
             ('rxnex', Compound('D', 'e'))
         ])
 
@@ -89,8 +89,8 @@ class TestCreateExtendedModel(unittest.TestCase):
             ('rxntp', Compound('B', 'c')): 3.0,
             ('rxntp', Compound('C', 'c')): 3.0,
             ('rxnex', Compound('A', 'e')): 2.0,
-            ('rxnex', Compound('B', 'c')): 2.0,
-            ('rxnex', Compound('C', 'c')): 2.0,
+            ('rxnex', Compound('B', 'e')): 2.0,
+            ('rxnex', Compound('C', 'e')): 2.0,
             ('rxnex', Compound('D', 'e')): 2.0
         }
         penalties = {'rxn_3': 5.6}

--- a/psamm/tests/test_fastgapfill.py
+++ b/psamm/tests/test_fastgapfill.py
@@ -32,40 +32,56 @@ from psamm.datasource.reaction import parse_reaction
 
 class TestCreateExtendedModel(unittest.TestCase):
     def setUp(self):
-        self._model_dir = tempfile.mkdtemp()
-        with open(os.path.join(self._model_dir, 'model.yaml'), 'w') as f:
-            f.write('\n'.join([
-                '---',
-                'reactions:',
-                '  - id: rxn_1',
-                '    equation: A[e] <=> B[c]',
-                '  - id: rxn_2',
-                '    equation: A[e] => C[c]',
-                '  - id: rxn_3',
-                '    equation: A[e] => D[e]',
-                '  - id: rxn_4',
-                '    equation: C[c] => D[e]',
-                'compounds:',
-                '  - id: A',
-                '  - id: B',
-                '  - id: C',
-                '  - id: D',
-                'media:',
-                '  - compartment: e',
-                '    compounds:',
-                '      - id: A',
-                '        reaction: rxn_5',
-                '      - id: D',
-                '        reaction: rxn_6',
-                'model:',
-                '  - reactions:',
-                '     - rxn_1',
-                '     - rxn_2',
-            ]))
-        self._model = NativeModel.load_model_from_path(self._model_dir)
-
-    def tearDown(self):
-        shutil.rmtree(self._model_dir)
+        self._model = NativeModel({
+            'compartments': [
+                {
+                    'id': 'c',
+                    'adjacent_to': 'e'
+                }, {
+                    'id': 'e'
+                }
+            ],
+            'reactions': [
+                {
+                    'id': 'rxn_1',
+                    'equation': 'A[e] <=> B[c]'
+                }, {
+                    'id': 'rxn_2',
+                    'equation': 'A[e] => C[c]'
+                }, {
+                    'id': 'rxn_3',
+                    'equation': 'A[e] => D[e]'
+                }, {
+                    'id': 'rxn_4',
+                    'equation': 'C[c] => D[e]'
+                }
+            ],
+            'compounds': [
+                {'id': 'A'},
+                {'id': 'B'},
+                {'id': 'C'},
+                {'id': 'D'}
+            ],
+            'media': [{
+                'compartment': 'e',
+                'compounds': [
+                    {
+                        'id': 'A',
+                        'reaction': 'rxn_5'
+                    },
+                    {
+                        'id': 'D',
+                        'reaction': 'rxn_6'
+                    }
+                ]
+            }],
+            'model': [{
+                'reactions': [
+                    'rxn_1',
+                    'rxn_2'
+                ]
+            }]
+        })
 
     def test_create_model_extended(self):
         expected_reactions = set([
@@ -75,6 +91,10 @@ class TestCreateExtendedModel(unittest.TestCase):
             'rxn_4',
             'rxn_5',
             'rxn_6',
+            ('rxntp', Compound('A', 'c'), Compound('A', 'e')),
+            ('rxntp', Compound('B', 'c'), Compound('B', 'e')),
+            ('rxntp', Compound('C', 'c'), Compound('C', 'e')),
+            ('rxntp', Compound('D', 'c'), Compound('D', 'e')),
             ('rxnex', Compound('A', 'e')),
             ('rxnex', Compound('B', 'e')),
             ('rxnex', Compound('C', 'e')),
@@ -84,6 +104,10 @@ class TestCreateExtendedModel(unittest.TestCase):
         expected_weights = {
             'rxn_3': 5.6,
             'rxn_4': 1.0,
+            ('rxntp', Compound('A', 'c'), Compound('A', 'e')): 3.0,
+            ('rxntp', Compound('B', 'c'), Compound('B', 'e')): 3.0,
+            ('rxntp', Compound('C', 'c'), Compound('C', 'e')): 3.0,
+            ('rxntp', Compound('D', 'c'), Compound('D', 'e')): 3.0,
             ('rxnex', Compound('A', 'e')): 2.0,
             ('rxnex', Compound('B', 'e')): 2.0,
             ('rxnex', Compound('C', 'e')): 2.0,

--- a/psamm/tests/test_fastgapfill.py
+++ b/psamm/tests/test_fastgapfill.py
@@ -75,8 +75,6 @@ class TestCreateExtendedModel(unittest.TestCase):
             'rxn_4',
             'rxn_5',
             'rxn_6',
-            ('rxntp', Compound('B', 'c')),
-            ('rxntp', Compound('C', 'c')),
             ('rxnex', Compound('A', 'e')),
             ('rxnex', Compound('B', 'e')),
             ('rxnex', Compound('C', 'e')),
@@ -86,8 +84,6 @@ class TestCreateExtendedModel(unittest.TestCase):
         expected_weights = {
             'rxn_3': 5.6,
             'rxn_4': 1.0,
-            ('rxntp', Compound('B', 'c')): 3.0,
-            ('rxntp', Compound('C', 'c')): 3.0,
             ('rxnex', Compound('A', 'e')): 2.0,
             ('rxnex', Compound('B', 'e')): 2.0,
             ('rxnex', Compound('C', 'e')): 2.0,

--- a/psamm/tests/test_metabolicmodel.py
+++ b/psamm/tests/test_metabolicmodel.py
@@ -47,12 +47,12 @@ class TestLoadMetabolicModel(unittest.TestCase):
 class TestMetabolicModel(unittest.TestCase):
     def setUp(self):
         self.database = DictDatabase()
-        self.database.set_reaction('rxn_1', parse_reaction('=> (2) |A|'))
-        self.database.set_reaction('rxn_2', parse_reaction('|A| <=> |B|'))
-        self.database.set_reaction('rxn_3', parse_reaction('|A| => |D[e]|'))
-        self.database.set_reaction('rxn_4', parse_reaction('|A| => |C|'))
-        self.database.set_reaction('rxn_5', parse_reaction('|C| => |D[e]|'))
-        self.database.set_reaction('rxn_6', parse_reaction('|D[e]| =>'))
+        self.database.set_reaction('rxn_1', parse_reaction('=> (2) A[c]'))
+        self.database.set_reaction('rxn_2', parse_reaction('A[c] <=> B[c]'))
+        self.database.set_reaction('rxn_3', parse_reaction('A[c] => D[e]'))
+        self.database.set_reaction('rxn_4', parse_reaction('A[c] => C[c]'))
+        self.database.set_reaction('rxn_5', parse_reaction('C[c] => D[e]'))
+        self.database.set_reaction('rxn_6', parse_reaction('D[e] =>'))
         self.model = MetabolicModel.load_model(
             self.database, self.database.reactions)
 
@@ -66,14 +66,14 @@ class TestMetabolicModel(unittest.TestCase):
 
     def test_compound_set(self):
         self.assertEqual(set(self.model.compounds),
-                        {Compound('A'), Compound('B'),
-                         Compound('C'), Compound('D', 'e')})
+                        {Compound('A', 'c'), Compound('B', 'c'),
+                         Compound('C', 'c'), Compound('D', 'e')})
 
     def test_compartments(self):
-        self.assertEqual(set(self.model.compartments), {None, 'e'})
+        self.assertEqual(set(self.model.compartments), {'c', 'e'})
 
     def test_add_reaction_new(self):
-        self.database.set_reaction('rxn_7', parse_reaction('|D[e]| => |E[e]|'))
+        self.database.set_reaction('rxn_7', parse_reaction('D[e] => E[e]'))
         self.model.add_reaction('rxn_7')
         self.assertIn('rxn_7', set(self.model.reactions))
         self.assertIn(Compound('E', 'e'), set(self.model.compounds))
@@ -83,9 +83,9 @@ class TestMetabolicModel(unittest.TestCase):
         self.assertEqual(
             set(self.model.reactions),
             {'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6'})
-        self.assertEqual(
-            set(self.model.compounds),
-            {Compound('A'), Compound('B'), Compound('C'), Compound('D', 'e')})
+        self.assertEqual(set(self.model.compounds), {
+            Compound('A', 'c'), Compound('B', 'c'), Compound('C', 'c'),
+            Compound('D', 'e')})
 
     def test_add_reaction_invalid(self):
         with self.assertRaises(Exception):
@@ -96,9 +96,8 @@ class TestMetabolicModel(unittest.TestCase):
         self.assertEqual(
             set(self.model.reactions),
             {'rxn_1', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6'})
-        self.assertEqual(
-            set(self.model.compounds),
-            {Compound('A'), Compound('C'), Compound('D', 'e')})
+        self.assertEqual(set(self.model.compounds), {
+            Compound('A', 'c'), Compound('C', 'c'), Compound('D', 'e')})
 
     def test_is_reversible_on_reversible(self):
         self.assertTrue(self.model.is_reversible('rxn_2'))
@@ -121,17 +120,18 @@ class TestMetabolicModel(unittest.TestCase):
         self.assertFalse(self.model.is_exchange('rxn_7'))
 
     def test_add_all_database_reactions(self):
-        self.database.set_reaction('rxn_7', parse_reaction('|D| => |E|'))
-        added = self.model.add_all_database_reactions({None, 'e'})
+        self.database.set_reaction('rxn_7', parse_reaction('|D[c]| => |E[e]|'))
+        added = self.model.add_all_database_reactions({'c', 'e'})
         self.assertEqual(added, { 'rxn_7' })
         self.assertEqual(set(self.model.reactions), {
             'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6', 'rxn_7'
         })
 
     def test_add_all_database_reactions_none(self):
-        added = self.model.add_all_database_reactions({None, 'e'})
+        added = self.model.add_all_database_reactions({'c', 'e'})
         self.assertEqual(added, set())
-        self.assertEqual(set(self.model.reactions), { 'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6' })
+        self.assertEqual(set(self.model.reactions), {
+            'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6'})
 
     def test_add_all_transport_reactions(self):
         added = self.model.add_all_transport_reactions('e')
@@ -215,7 +215,8 @@ class TestMetabolicModel(unittest.TestCase):
         self.assertEqual(self.model.limits['rxn_2'].bounds, (-10, 1000))
 
     def test_limits_iter(self):
-        self.assertEqual(set(iter(self.model.limits)), { 'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6' })
+        self.assertEqual(set(iter(self.model.limits)), {
+            'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6'})
 
     def test_limits_len(self):
         self.assertEqual(len(self.model.limits), 6)

--- a/psamm/tests/test_metabolicmodel.py
+++ b/psamm/tests/test_metabolicmodel.py
@@ -120,9 +120,12 @@ class TestMetabolicModel(unittest.TestCase):
         self.assertFalse(self.model.is_exchange('rxn_7'))
 
     def test_add_all_database_reactions(self):
-        self.database.set_reaction('rxn_7', parse_reaction('|D[c]| => |E[e]|'))
+        # Should get added
+        self.database.set_reaction('rxn_7', parse_reaction('D[c] => E[c]'))
+        # Not added because of compartment
+        self.database.set_reaction('rxn_8', parse_reaction('D[c] => E[p]'))
         added = self.model.add_all_database_reactions({'c', 'e'})
-        self.assertEqual(added, { 'rxn_7' })
+        self.assertEqual(added, {'rxn_7'})
         self.assertEqual(set(self.model.reactions), {
             'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6', 'rxn_7'
         })

--- a/psamm/tests/test_metabolicmodel.py
+++ b/psamm/tests/test_metabolicmodel.py
@@ -137,7 +137,7 @@ class TestMetabolicModel(unittest.TestCase):
             'rxn_1', 'rxn_2', 'rxn_3', 'rxn_4', 'rxn_5', 'rxn_6'})
 
     def test_add_all_transport_reactions(self):
-        added = self.model.add_all_transport_reactions('e')
+        added = self.model.add_all_transport_reactions({('e', 'c')})
         for reaction in added:
             compartments = tuple(c.compartment for c, _ in
                                  self.model.get_reaction_values(reaction))


### PR DESCRIPTION
Use compartment boundary information to decide which artificial transport reactions to generate for gap-filling. For consistency, also add database reactions based on the compartments specified in the model (i.e. only add database reactions that are within model compartments as specified in `model.yaml`). This means that now compartments must be defined when using database reactions for gap-filling.