### PR TITLE
Add options to gapfill command

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -380,9 +380,10 @@ command is a variant of the gap-filling procedure described in [Kumar07]_.
 
 The command will first list the reactions in the model followed by the
 suggested reactions to add to the model in order to unblock the blocked
-compounds. The procedure may also suggest that existing model reactions have
-their flux bounds widened, e.g. making an existing irreversible reaction
-reversible. To unblock only specific compounds, use the ``--compound`` option:
+compounds. If ``--allow-bounds-expansion`` is specified, the procedure may also
+suggest that existing model reactions have their flux bounds widened, e.g.
+making an existing irreversible reaction reversible. To unblock only specific
+compounds, use the ``--compound`` option:
 
 .. code-block:: shell
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -401,6 +401,12 @@ file name with ``@``.
 The GapFind algorithm is defined in terms of a MILP problem and can therefore
 be computationally expensive to run for larger models.
 
+The original GapFill algorithm uses a solution procedure which implicitly
+assumes that the model contains implicit sinks for all compounds. This means
+that even with the reactions proposed by GapFill the model may need to produce
+compounds that cannot be used anywhere. The implicit sinks can be disabled
+with the ``--no-implicit-sinks`` option.
+
 FastGapFill (``fastgapfill``)
 -----------------------------
 

--- a/psamm/commands/gapfill.py
+++ b/psamm/commands/gapfill.py
@@ -124,19 +124,21 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
             rx = self._mm.get_reaction(reaction_id)
             rxt = rx.translated_compounds(
                 lambda x: compound_name.get(x, x))
-            print('{}\t{}\t{}'.format(reaction_id, 'Model', rxt))
+            print('{}\t{}\t{}\t{}'.format(reaction_id, 'Model', 0, rxt))
 
         for rxnid in sorted(added_reactions):
             rx = model_complete.get_reaction(rxnid)
             rxt = rx.translated_compounds(
                 lambda x: compound_name.get(x, x))
-            print('{}\t{}\t{}'.format(rxnid, 'Add', rxt))
+            print('{}\t{}\t{}\t{}'.format(
+                rxnid, 'Add', weights.get(rxnid, 1), rxt))
 
         for rxnid in sorted(no_bounds_reactions):
             rx = model_complete.get_reaction(rxnid)
             rxt = rx.translated_compounds(
                 lambda x: compound_name.get(x, x))
-            print('{}\t{}\t{}'.format(rxnid, 'Remove bounds', rxt))
+            print('{}\t{}\t{}\t{}'.format(
+                rxnid, 'Remove bounds', weights.get(rxnid, 1), rxt))
 
     def _log_epsilon_and_fail(self, epsilon, exc):
         msg = ('Finding blocked compounds failed with epsilon set to {}. Try'

--- a/psamm/commands/gapfill.py
+++ b/psamm/commands/gapfill.py
@@ -54,6 +54,9 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
         parser.add_argument(
             '--epsilon', type=float, default=1e-5,
             help='Threshold for reaction flux')
+        parser.add_argument(
+            '--no-implicit-sinks', action='store_true',
+            help='Do not include implicit sinks when gap-filling')
         super(GapFillCommand, cls).init_parser(parser)
 
     def run(self):
@@ -112,11 +115,14 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
             tp_penalty=self._args.tp_penalty,
             penalties=penalties)
 
+        implicit_sinks = not self._args.no_implicit_sinks
+
         logger.info('Searching for reactions to fill gaps')
         try:
             added_reactions, no_bounds_reactions = gapfill(
                 model_complete, core, blocked, exclude, solver=solver,
-                epsilon=epsilon, v_max=v_max, weights=weights)
+                epsilon=epsilon, v_max=v_max, weights=weights,
+                implicit_sinks=implicit_sinks)
         except GapFillError as e:
             self._log_epsilon_and_fail(epsilon, e)
 

--- a/psamm/commands/gapfill.py
+++ b/psamm/commands/gapfill.py
@@ -57,6 +57,10 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
         parser.add_argument(
             '--no-implicit-sinks', action='store_true',
             help='Do not include implicit sinks when gap-filling')
+        parser.add_argument(
+            '--allow-bounds-expansion', action='store_true',
+            help=('Allow GapFill to propose expansion of flux bounds. This'
+                  ' includes turning irreversible reactions reversible.'))
         super(GapFillCommand, cls).init_parser(parser)
 
     def run(self):
@@ -122,7 +126,8 @@ class GapFillCommand(MetabolicMixin, SolverCommandMixin, Command):
             added_reactions, no_bounds_reactions = gapfill(
                 model_complete, core, blocked, exclude, solver=solver,
                 epsilon=epsilon, v_max=v_max, weights=weights,
-                implicit_sinks=implicit_sinks)
+                implicit_sinks=implicit_sinks,
+                allow_bounds_expansion=self._args.allow_bounds_expansion)
         except GapFillError as e:
             self._log_epsilon_and_fail(epsilon, e)
 

--- a/psamm/gapfill.py
+++ b/psamm/gapfill.py
@@ -62,6 +62,14 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000):
 
     This method is implemented as a MILP-program. Therefore it may
     not be efficient for larger models.
+
+    Args:
+        model: :class:`MetabolicModel` containing core reactions and reactions
+            that can be added for gap-filling.
+        solver: MILP solver instance.
+        epsilon: Threshold amount of a compound produced for it to not be
+            considered blocked.
+        v_max: Maximum flux.
     """
     prob = solver.create_problem()
 
@@ -141,15 +149,23 @@ def gapfill(
     it. This means that the resulting model will not necessarily be
     flux consistent.
 
-    Core indicates the core set of reactions in the model. GapFill will
-    minimize the number of added reactions that are not in core. Blocked
-    indicates the set of compounds to be resolved. Exclude is a set of
-    reactions that cannot be changed used for gap-filling. Epsilon indicates
-    the threshold amount of a compound produced for it to not be considered
-    blocked. V_max indicates the maximum flux.
-
     This method is implemented as a MILP-program. Therefore it may
     not be efficient for larger models.
+
+    Args:
+        model: :class:`MetabolicModel` containing core reactions and reactions
+            that can be added for gap-filling.
+        core: The set of core (already present) reactions in the model.
+        blocked: The compounds to unblock.
+        exclude: Set of reactions in core to be excluded from gap-filling (e.g.
+            biomass reaction).
+        solver: MILP solver instance.
+        epsilon: Threshold amount of a compound produced for it to not be
+            considered blocked.
+        v_max: Maximum flux.
+        weights: Dictionary of weights for reactions. Weight is the penalty
+            score for adding the reaction (non-core reactions) or expanding the
+            flux bounds (all reactions).
     """
     prob = solver.create_problem()
 

--- a/psamm/gapfill.py
+++ b/psamm/gapfill.py
@@ -141,7 +141,7 @@ def gapfind(model, solver, epsilon=0.001, v_max=1000, implicit_sinks=True):
 
 def gapfill(
         model, core, blocked, exclude, solver, epsilon=0.001, v_max=1000,
-        weights={}, implicit_sinks=True):
+        weights={}, implicit_sinks=True, allow_bounds_expansion=False):
     """Find a set of reactions to add such that no compounds are blocked.
 
     Returns two iterators: first an iterator of reactions not in
@@ -173,6 +173,10 @@ def gapfill(
             flux bounds (all reactions).
         implicit_sinks: Whether implicit sinks for all compounds are included
             when gap-filling (traditional GapFill uses implicit sinks).
+        allow_bounds_expansion: Allow flux bounds to be expanded at the cost
+            of a penalty which can be specified using weights (traditional
+            GapFill does not allow this). This includes turning irreversible
+            reactions reversible.
     """
     prob = solver.create_problem()
 
@@ -200,7 +204,7 @@ def gapfill(
     for reaction_id in model.reactions:
         lower, upper = (float(x) for x in model.limits[reaction_id])
 
-        if reaction_id in exclude:
+        if reaction_id in exclude or not allow_bounds_expansion:
             prob.add_linear_constraints(
                 upper >= v(reaction_id), v(reaction_id) >= lower)
         else:

--- a/psamm/tests/test_gapfill.py
+++ b/psamm/tests/test_gapfill.py
@@ -70,9 +70,19 @@ class TestGapfind(unittest.TestCase):
         blocked = {Compound('D'), Compound('E')}
 
         add, rev = gapfill(
-            self.model, core, blocked, {}, self.solver, epsilon=0.1)
+            self.model, core, blocked, {}, self.solver, epsilon=0.1,
+            allow_bounds_expansion=True)
         self.assertEqual(set(rev), {'rxn_4'})
         self.assertEqual(set(add), set())
+
+    def test_gapfill_reverse_reaction_not_allowed(self):
+        self.model.database.set_reaction('rxn_4', parse_reaction('|D| => |C|'))
+        core = set(self.model.reactions)
+        blocked = {Compound('D'), Compound('E')}
+
+        with self.assertRaises(GapFillError):
+            add, rev = gapfill(
+                self.model, core, blocked, {}, self.solver, epsilon=0.1)
 
     def test_gapfill_exclude_reversal(self):
         self.model.database.set_reaction('rxn_4', parse_reaction('D => C'))


### PR DESCRIPTION
- Show weight of proposed changes in output. This is similar to the output of the `fastgapfill` command and makes it easier to determine why a particular solution was found.
- Add option `--no-implicit-sinks` to disable implicit sinks in the `gapfill` command.
- Add option `--allow-bounds-expansion` to allow GapFill to propose expansion of flux bounds as a possible solution. This also includes making irreversible reactions reversible. This is disabled by default in line with the original GapFill algorithm. 