### PR TITLE
Fix issues with non-float numbers provided to solver

### DIFF
--- a/psamm/lpsolver/cplex.py
+++ b/psamm/lpsolver/cplex.py
@@ -245,7 +245,7 @@ class Problem(BaseProblem):
         for var, value in expression.values():
             if not isinstance(var, Product):
                 self._non_zero_objective.add(var)
-                linear.append((self._variables[var], value))
+                linear.append((self._variables[var], float(value)))
             else:
                 if len(var) > 2:
                     raise ValueError('Invalid objective: {}'.format(var))
@@ -254,7 +254,7 @@ class Problem(BaseProblem):
                 var2 = self._variables[var[1]]
                 if var1 == var2:
                     value *= 2
-                quad.append((var1, var2, value))
+                quad.append((var1, var2, float(value)))
 
         # We have to build the set of variables to
         # update so that we can avoid calling set_linear if the set is empty.
@@ -266,7 +266,7 @@ class Problem(BaseProblem):
             self._cp.objective.set_quadratic_coefficients(quad)
 
         if hasattr(self._cp.objective, 'set_offset'):
-            self._cp.objective.set_offset(expression.offset)
+            self._cp.objective.set_offset(float(expression.offset))
 
     set_linear_objective = set_objective
     """Set objective of the problem.

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -253,9 +253,9 @@ class Problem(BaseProblem):
 
         for variable, value in expression.values():
             var_index = self._variables[variable]
-            swiglpk.glp_set_obj_coef(self._p, var_index, value)
+            swiglpk.glp_set_obj_coef(self._p, var_index, float(value))
 
-        swiglpk.glp_set_obj_coef(self._p, 0, expression.offset)
+        swiglpk.glp_set_obj_coef(self._p, 0, float(expression.offset))
 
     set_linear_objective = set_objective
     """Set objective of the problem.

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -408,21 +408,19 @@ class Result(BaseResult):
             return 'No dual feasible solution'
         return str(swiglpk.glp_get_status(self._problem._p))
 
-    def _get_var_value(self, variable):
-        self._check_valid()
-        if variable not in self._problem._variables:
-            raise ValueError('Unknown variable: {}'.format(variable))
+    def _has_variable(self, variable):
+        """Whether variable exists in the solution."""
+        return self._problem.has_variable(variable)
+
+    def _get_value(self, variable):
+        """Return value of variable in solution."""
         return swiglpk.glp_get_col_prim(
             self._problem._p, self._problem._variables[variable])
 
     def get_value(self, expression):
         """Return value of expression."""
-
         self._check_valid()
-        if isinstance(expression, Expression):
-            return sum(self._get_var_value(var) * value
-                       for var, value in expression.values())
-        return self._get_var_value(expression)
+        return super(Result, self).get_value(expression)
 
 
 class MIPResult(Result):
@@ -438,9 +436,7 @@ class MIPResult(Result):
         self._check_valid()
         return str(swiglpk.glp_mip_status(self._problem._p))
 
-    def _get_var_value(self, variable):
-        self._check_valid()
-        if variable not in self._problem._variables:
-            raise ValueError('Unknown variable: {}'.format(variable))
+    def _get_value(self, variable):
+        """Return value of variable in solution."""
         return swiglpk.glp_mip_col_val(
             self._problem._p, self._problem._variables[variable])

--- a/psamm/tests/test_lpsolver_generic.py
+++ b/psamm/tests/test_lpsolver_generic.py
@@ -14,12 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2015-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 import os
 import unittest
+from decimal import Decimal
+from fractions import Fraction
 
-from psamm.lpsolver import generic
+from psamm.lpsolver import generic, lp
 
 
 class TestSolverProblem(unittest.TestCase):
@@ -33,6 +35,40 @@ class TestSolverProblem(unittest.TestCase):
             self.solver = generic.Solver()
         except generic.RequirementsError:
             self.skipTest('Unable to find an LP solver for tests')
+
+    def test_set_decimal_variable_bounds(self):
+        """Test that Decimal can be used for variable bounds."""
+        prob = self.solver.create_problem()
+        prob.define('x', lower=Decimal('3.5'), upper=Decimal('500.3'))
+
+    def test_set_decimal_objective(self):
+        """Test that Decimal can be used in objective."""
+        prob = self.solver.create_problem()
+        prob.define('x', lower=3, upper=100)
+        prob.set_objective(Decimal('3.4') * prob.var('x'))
+
+    def test_set_fraction_objective(self):
+        """Test that Fraction can be used in objective."""
+        prob = self.solver.create_problem()
+        prob.define('x', lower=-5, upper=5)
+        prob.set_objective(Fraction(1, 2) * prob.var('x'))
+
+    def test_set_decimal_constraint(self):
+        """Test that Decimal can be used in constraints."""
+        prob = self.solver.create_problem()
+        prob.define('x', lower=0, upper=5)
+        prob.add_linear_constraints(
+            Decimal('5.6') * prob.var('x') >= Decimal('8.9'))
+
+    def test_result_evaluate_decimal_expression(self):
+        """Test that Decimal in expression can be used to evaluate result."""
+        prob = self.solver.create_problem()
+        prob.define('x', lower=0, upper=Fraction(5, 2))
+        prob.add_linear_constraints(prob.var('x') >= 2)
+        prob.set_objective(prob.var('x'))
+        result = prob.solve(lp.ObjectiveSense.Maximize)
+        value = result.get_value(Decimal('3.4') * prob.var('x'))
+        self.assertAlmostEqual(value, Fraction(17, 2))
 
     def test_redefine_variable(self):
         """Test that redefining a variable fails."""


### PR DESCRIPTION
- Fixes issues in `cplex` and `glpk` where an expression supplied as objective containing non-float numbers results in an exception.
- Fixes general expression evaluation in `Result` base class in `lp` module to be able to handle expressions with non-float numbers.