### PR TITLE
WIP: gapfind: Alternative GapFind algorithm which is more robust

### DIFF
--- a/psamm/commands/gapcheck.py
+++ b/psamm/commands/gapcheck.py
@@ -46,11 +46,10 @@ class GapCheckCommand(MetabolicMixin, SolverCommandMixin, Command):
         solver = self._get_solver(integer=True)
         extracellular_comp = self._model.extracellular_compartment
         epsilon = self._args.epsilon
-        v_max = float(self._model.default_flux_limit)
 
         # Run GapFind on model
         logger.info('Searching for blocked compounds...')
-        result = gapfind(self._mm, solver=solver, epsilon=epsilon, v_max=v_max)
+        result = gapfind(self._mm, solver=solver, epsilon=epsilon)
 
         try:
             blocked = set(compound for compound in result


### PR DESCRIPTION
This is one attempt at finding an alternative implementation of GapFind that works correctly on larger models instead of marking almost all compounds blocked.

Does not depend on v_max, instead sets a maximum flux when solving this problem to 1. This reduces the distance between `v_max` and `epsilon` making the problem more robust. This is
able to solve larger models that fail with the previous implementation. This respects reaction directionality but ignores any reaction flux limits. This also lowers the maximum flux which scales the solution. This means that generally there could be some reactions that may not be able to produce epsilon flux.