### PR TITLE
lp: Raise error on certain use of Expression/Relation

### DIFF
--- a/psamm/lpsolver/lp.py
+++ b/psamm/lpsolver/lp.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Base objects for representation of LP problems.
 
@@ -166,6 +166,12 @@ class Expression(object):
     >>> rel = Expression({'x': 2}) >= Expression({'y': 3})
     >>> str(rel)
     '2*x - 3*y >= 0'
+
+    .. warning::
+
+        Chained relations cannot be converted to multiple
+        relations, e.g. ``4 <= e <= 10`` will fail to produce the intended
+        relations!
     """
 
     def __init__(self, variables={}, offset=0):
@@ -491,6 +497,17 @@ class Relation(object):
 
     def __repr__(self):
         return str('<{} {}>').format(self.__class__.__name__, repr(str(self)))
+
+    def __nonzero__(self):
+        # Override __nonzero__ (and __bool__) here so we can avoid bugs when a
+        # user mistakenly thinks that "4 <= x <= 100" should work.
+        # This kind of expression expands to "4 <= x and x <= 100" and since we
+        # cannot override the "and" operator, the relation "4 <= x" is
+        # converted to a bool. Override here to raise an error to make sure
+        # that this syntax always fails.
+        raise ValueError('Unable to convert relation to bool')
+
+    __bool__ = __nonzero__
 
 
 @enum.unique

--- a/psamm/tests/test_lpsolver_lp.py
+++ b/psamm/tests/test_lpsolver_lp.py
@@ -330,6 +330,11 @@ class TestRelation(unittest.TestCase):
         r = lp.Relation(lp.RelationSense.Equals, e)
         self.assertEqual(str(r), 'x1 == 0')
 
+    def test_chained_relation(self):
+        e = lp.Expression({'x1': 1})
+        with self.assertRaises(ValueError):
+            self.assertFalse(4 <= e <= 10)
+
 
 class MockResult(lp.Result):
     def __init__(self, values):

--- a/psamm/tests/test_lpsolver_lp.py
+++ b/psamm/tests/test_lpsolver_lp.py
@@ -14,12 +14,15 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2015-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 import math
 import unittest
 
 from psamm.lpsolver import lp
+
+# Beware: Expressions cannot be tested for equality using normal
+# assertEqual because the equality operator is overloaded!
 
 
 class DummyRangedPropertyContainer(object):
@@ -306,10 +309,15 @@ class TestExpression(unittest.TestCase):
 
 
 class TestRelation(unittest.TestCase):
+    def assertExpressionEqual(self, e1, e2):
+        """Assert that expressions are equal."""
+        self.assertEqual(e1.offset, e2.offset)
+        self.assertEqual(dict(e1.values()), dict(e2.values()))
+
     def test_create_relation(self):
         e = lp.Expression({'x1': 4})
         r = lp.Relation(lp.RelationSense.Greater, e)
-        self.assertEqual(r.expression, e)
+        self.assertExpressionEqual(r.expression, e)
         self.assertEqual(r.sense, lp.RelationSense.Greater)
 
     def test_relation_with_offset_to_string(self):


### PR DESCRIPTION
Raise an error when using chained comparisons with an Expression object, e.g. 4 <= x <= 100 where x is an Expression object. This expands to 4 <= x and x <= 100 but the "and" operator cannot be overridden and currently it simply discards the first part of the constraint because the Relation object created from 4 <= x simply evaluates to True. Raising an error seems to be the best way to catch this kind of mistake.

A test was fixed in the first commit because it mistakenly used `assertEqual` to compare expression objects. `assertEqual` cannot be used for Expressions because the equality operator is overridden to construct Relation objects.