### PR TITLE
Rename media to exchange

### DIFF
--- a/docs/file_format.rst
+++ b/docs/file_format.rst
@@ -31,8 +31,8 @@ used as a template:
       - include: reactions/reactions.tsv
       - include: reactions/biomass.yaml
 
-    media:
-      - include: medium.yaml
+    exchange:
+      - include: exchange.yaml
     limits:
       - include: limits.yaml
 
@@ -188,13 +188,21 @@ group of genes or when multiple genes can independently enable a reaction:
       equation: '|amp| + |atp| <=> (2) |adp|'
       genes: gene_0001 or (gene_0002 and gene_0003)
 
-Media
------
+Exchange compounds
+------------------
 
-The optional ``media`` key provides a way of defining the medium (boundary
-conditions) for the model. The medium is defined by a set of compounds that are
-able enter or leave the model system. The following fragment is an example of
-the ``medium.yaml`` file:
+The ``exchange`` key provides a way of defining the compounds that can
+enter and exit the model system (the boundary conditions). This includes
+compounds that can enter the system (*the medium*) and compounds that are
+allowed to exit the system, like metabolic byproducts. In most cases, all
+compounds that occur in the extracellular space should also be defined in the
+exchange compounds (with lower limit of zero) so that they are allowed to
+leave the model system, and PSAMM will generate a warning if this is not the
+case for some compounds. Compounds that are allowed to be taken up
+(*the medium*) should in addition be specified with a negative lower limit
+indicating the maximum allowed uptake.
+
+The following fragment is an example of the ``exchange.yaml`` file:
 
 .. code-block:: yaml
 
@@ -205,21 +213,18 @@ the ``medium.yaml`` file:
       - id: o2
       - id: glcD    # D-Glucose with uptake limit of 10
         lower: -10
-      - id: compound_x
-        compartment: c
-        lower: 0    # Provide a sink for compound_x
       # ...
 
-When a medium file is specified, the corresponding exchange reactions are
+When an exchange file is specified, the corresponding exchange reactions are
 automatically added. For example, if the compounds ``o2`` in compartment ``e``
-is in the medium, the exchange reaction ``EX_o2_e`` is added to the model. The
-desired ID for the exchange reaction can be set explicitly using the
+is in the exchange file, the exchange reaction ``EX_o2_e`` is added to the
+model. The desired ID for the exchange reaction can be set explicitly using the
 ``reaction`` attribute.
 
-The medium can also be specified using a TSV-file as the following fragment
-shows. The second column specifies the compartment while third and fourth
-columns specify the lower and upper bounds, respectively. Both can be omitted
-or specified as ``-`` to use the default flux bounds::
+The exchange set can also be specified using a TSV-file as the following
+fragment shows. The second column specifies the compartment while third and
+fourth columns specify the lower and upper bounds, respectively. Both can be
+omitted or specified as ``-`` to use the default flux bounds::
 
     # Acetate exchange with default lower and upper bounds
     ac      e
@@ -228,8 +233,9 @@ or specified as ``-`` to use the default flux bounds::
     # CO2 exchange with production limit of 50 and default uptake limit
     co2     e       -       50
 
-Multiple medium files can be included from the main ``model.yaml`` file, and
-these will be combined to form the final medium used for the simulations.
+Multiple exchange files can be included from the main ``exchange.yaml`` file,
+and these will be combined to form the final set of exchange reactions used for
+the simulations.
 
 Reaction flux limits
 --------------------

--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -101,27 +101,27 @@ class ExcelExportCommand(Command):
                 compound_sheet.write_string(
                     x+1, len(compound_list_sorted), 'False')
 
-        media_sheet = workbook.add_worksheet(name='Exchange')
+        exchange_sheet = workbook.add_worksheet(name='Exchange')
 
-        media_sheet.write_string(0, 0, 'Compound ID')
-        media_sheet.write_string(0, 1, 'Reaction ID')
-        media_sheet.write_string(0, 2, 'Lower Limit')
-        media_sheet.write_string(0, 3, 'Upper Limit')
+        exchange_sheet.write_string(0, 0, 'Compound ID')
+        exchange_sheet.write_string(0, 1, 'Reaction ID')
+        exchange_sheet.write_string(0, 2, 'Lower Limit')
+        exchange_sheet.write_string(0, 3, 'Upper Limit')
 
         default_flux = model.default_flux_limit
 
         for x, (compound, reaction, lower, upper) in enumerate(
-                model.parse_medium()):
+                model.parse_exchange()):
             if lower is None:
                 lower = -1 * default_flux
 
             if upper is None:
                 upper = default_flux
 
-            media_sheet.write(x+1, 0, text_type(compound))
-            media_sheet.write(x+1, 1, text_type(reaction))
-            media_sheet.write(x+1, 2, text_type(lower))
-            media_sheet.write(x+1, 3, text_type(upper))
+            exchange_sheet.write(x+1, 0, text_type(compound))
+            exchange_sheet.write(x+1, 1, text_type(reaction))
+            exchange_sheet.write(x+1, 2, text_type(lower))
+            exchange_sheet.write(x+1, 3, text_type(upper))
 
         limits_sheet = workbook.add_worksheet(name='Limits')
 

--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -14,6 +14,7 @@
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright 2015  Keith Dufault-Thompson <keitht547@my.uri.edu>
+# Copyright 2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from __future__ import unicode_literals
 
@@ -33,12 +34,13 @@ logger = logging.getLogger(__name__)
 
 
 class ExcelExportCommand(Command):
-    """Export the metabolic model as an Excel workbook"""
+    """Export the metabolic model as an Excel workbook."""
 
     @classmethod
     def init_parser(cls, parser):
         parser.add_argument(
-            'file', type=str, help='File path for writing the Excel workbook')
+            'file', type=text_type,
+            help='File path for writing the Excel workbook')
 
     def run(self):
         model = self._model

--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -101,7 +101,7 @@ class ExcelExportCommand(Command):
                 compound_sheet.write_string(
                     x+1, len(compound_list_sorted), 'False')
 
-        media_sheet = workbook.add_worksheet(name='Medium')
+        media_sheet = workbook.add_worksheet(name='Exchange')
 
         media_sheet.write_string(0, 0, 'Compound ID')
         media_sheet.write_string(0, 1, 'Reaction ID')

--- a/psamm/commands/tableexport.py
+++ b/psamm/commands/tableexport.py
@@ -14,6 +14,7 @@
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright 2015  Keith Dufault-Thompson <keitht547@my.uri.edu>
+# copyright 2017  Jon Lund Steffensen <jon_steffensen@uri.edi>
 
 from __future__ import unicode_literals
 
@@ -54,7 +55,7 @@ class ExportTableCommand(Command):
 
     - reactions: Export reactions and reaction metadata
     - compounds: Export compounds and compound metadata
-    - medium: Export the list of exchange compounds/reactions
+    - exchange: Export the list of exchange compounds/reactions
     - limits: Export list of internal flux limits
     - metadata: Export general model metadata
     """
@@ -63,7 +64,8 @@ class ExportTableCommand(Command):
     def init_parser(cls, parser):
         parser.add_argument(
             'export', metavar='export_type',
-            choices=['reactions', 'compounds', 'medium', 'limits', 'metadata'],
+            choices=['reactions', 'compounds', 'medium', 'exchange', 'limits',
+                     'metadata'],
             help='Type of model data to export')
 
     def run(self):
@@ -72,7 +74,7 @@ class ExportTableCommand(Command):
             self._reaction_export()
         elif export_type == 'compounds':
             self._compound_export()
-        elif export_type == 'medium':
+        elif export_type == 'exchange' or export_type == 'medium':
             self._media_export()
         elif export_type == 'limits':
             self._limits_export()

--- a/psamm/commands/tableexport.py
+++ b/psamm/commands/tableexport.py
@@ -75,7 +75,7 @@ class ExportTableCommand(Command):
         elif export_type == 'compounds':
             self._compound_export()
         elif export_type == 'exchange' or export_type == 'medium':
-            self._media_export()
+            self._exchange_export()
         elif export_type == 'limits':
             self._limits_export()
         elif export_type == 'metadata':
@@ -122,12 +122,12 @@ class ExportTableCommand(Command):
             line_content.append(in_model)
             print('\t'.join(_encode_value(value) for value in line_content))
 
-    def _media_export(self):
+    def _exchange_export(self):
         print('{}\t{}\t{}\t{}'.format('Compound ID', 'Reaction ID',
                                       'Lower Limit', 'Upper Limit'))
         default_flux = self._model.default_flux_limit
 
-        for compound, reaction, lower, upper in self._model.parse_medium():
+        for compound, reaction, lower, upper in self._model.parse_exchange():
             if lower is None:
                 lower = -1 * default_flux
 

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Module for reading and writing native formats.
 
@@ -272,13 +272,23 @@ class NativeModel(object):
         upper flux limits.
         """
 
-        extracellular = self.extracellular_compartment
         if 'media' in self._model:
-            if not isinstance(self._model['media'], list):
-                raise ParseError('Expected media to be a list')
+            if 'exchange' in self._model:
+                raise ParseError('Both "media" and "exchange" are specified')
+            logger.warning(
+                'The "media" key is deprecated! Please use "exchange" instead:'
+                ' https://psamm.readthedocs.io/en/stable/file_format.html')
+            exchange_list = self._model['media']
+        else:
+            exchange_list = self._model.get('exchange')
+
+        extracellular = self.extracellular_compartment
+        if exchange_list is not None:
+            if not isinstance(exchange_list, list):
+                raise ParseError('Expected "exchange" to be a list')
 
             for medium_compound in parse_medium_list(
-                    self._context, self._model['media'], extracellular):
+                    self._context, exchange_list, extracellular):
                 compound, reaction_id, lower, upper = medium_compound
                 if compound.compartment is None:
                     compound = compound.in_compartment(extracellular)

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -217,8 +217,8 @@ class NativeModel(object):
         """Default compartment specified by the model.
 
         The compartment that is implied when not specified. In some contexts
-        (e.g. medium) the extracellular compartment may be implied instead.
-        Defaults to 'c'.
+        (e.g. for exchange compounds) the extracellular compartment may be
+        implied instead. Defaults to 'c'.
         """
         return self._model.get('default_compartment', 'c')
 
@@ -265,10 +265,10 @@ class NativeModel(object):
                     self._context, self._model['limits']):
                 yield limit
 
-    def parse_medium(self):
-        """Yield tuples of medium compounds.
+    def parse_exchange(self):
+        """Yield tuples of exchange compounds.
 
-        Each medium compound is a tuple of compound, reaction ID, lower and
+        Each exchange compound is a tuple of compound, reaction ID, lower and
         upper flux limits.
         """
 
@@ -287,9 +287,9 @@ class NativeModel(object):
             if not isinstance(exchange_list, list):
                 raise ParseError('Expected "exchange" to be a list')
 
-            for medium_compound in parse_medium_list(
+            for exchange_compound in parse_exchange_list(
                     self._context, exchange_list, extracellular):
-                compound, reaction_id, lower, upper = medium_compound
+                compound, reaction_id, lower, upper = exchange_compound
                 if compound.compartment is None:
                     compound = compound.in_compartment(extracellular)
                 yield compound, reaction_id, lower, upper
@@ -345,18 +345,18 @@ class NativeModel(object):
                 'The compound {} was not defined in the list'
                 ' of compounds'.format(compound))
 
-        medium_compounds = set()
-        for medium_compound in self.parse_medium():
-            if medium_compound[0].compartment == extracellular:
-                medium_compounds.add(medium_compound[0].name)
+        exchange_compounds = set()
+        for compound, _, _, _ in self.parse_exchange():
+            if compound.compartment == extracellular:
+                exchange_compounds.add(compound.name)
 
-        for compound in sorted(extracellular_compounds - medium_compounds):
+        for compound in sorted(extracellular_compounds - exchange_compounds):
             logger.warning(
                 'The compound {} was in the extracellular compartment'
-                ' but not defined in the medium'.format(compound))
-        for compound in sorted(medium_compounds - extracellular_compounds):
+                ' but not defined in the exchange compounds'.format(compound))
+        for compound in sorted(exchange_compounds - extracellular_compounds):
             logger.warning(
-                'The compound {} was defined in the medium but'
+                'The compound {} was defined in the exchange compounds but'
                 ' is not in the extracellular compartment'.format(compound))
 
         model_definition = None
@@ -364,7 +364,7 @@ class NativeModel(object):
             model_definition = self.parse_model()
 
         return MetabolicModel.load_model(
-            database, model_definition, self.parse_medium(),
+            database, model_definition, self.parse_exchange(),
             self.parse_limits(), v_max=self.default_flux_limit)
 
     @property
@@ -682,15 +682,15 @@ def get_limits(compound_def):
     return lower, upper
 
 
-def parse_medium(medium_def, default_compartment):
-    """Parse a structured medium definition as obtained from a YAML file
+def parse_exchange(exchange_def, default_compartment):
+    """Parse a structured exchange definition as obtained from a YAML file.
 
     Returns in iterator of compound, reaction, lower and upper bounds.
     """
 
-    default_compartment = medium_def.get('compartment', default_compartment)
+    default_compartment = exchange_def.get('compartment', default_compartment)
 
-    for compound_def in medium_def.get('compounds', []):
+    for compound_def in exchange_def.get('compounds', []):
         compartment = compound_def.get('compartment', default_compartment)
         compound = Compound(compound_def['id'], compartment=compartment)
         reaction = compound_def.get('reaction')
@@ -698,8 +698,8 @@ def parse_medium(medium_def, default_compartment):
         yield compound, reaction, lower, upper
 
 
-def parse_medium_list(path, medium, default_compartment):
-    """Parse a structured medium list as obtained from a YAML file.
+def parse_exchange_list(path, exchange, default_compartment):
+    """Parse a structured exchange list as obtained from a YAML file.
 
     Yields tuples of compound, reaction ID, lower and upper flux bounds. Path
     can be given as a string or a context.
@@ -707,29 +707,29 @@ def parse_medium_list(path, medium, default_compartment):
 
     context = FilePathContext(path)
 
-    for medium_def in medium:
-        if 'include' in medium_def:
-            include_context = context.resolve(medium_def['include'])
-            for medium_compound in parse_medium_file(
+    for exchange_def in exchange:
+        if 'include' in exchange_def:
+            include_context = context.resolve(exchange_def['include'])
+            for exchange_compound in parse_exchange_file(
                     include_context, default_compartment):
-                yield medium_compound
+                yield exchange_compound
         else:
-            for medium_compound in parse_medium(
-                    medium_def, default_compartment):
-                yield medium_compound
+            for exchange_compound in parse_exchange(
+                    exchange_def, default_compartment):
+                yield exchange_compound
 
 
-def parse_medium_yaml_file(path, f, default_compartment):
-    """Parse a file as a YAML-format medium definition
+def parse_exchange_yaml_file(path, f, default_compartment):
+    """Parse a file as a YAML-format exchange definition.
 
     Path can be given as a string or a context.
     """
 
-    return parse_medium(yaml_load(f), default_compartment)
+    return parse_exchange(yaml_load(f), default_compartment)
 
 
-def parse_medium_table_file(f):
-    """Parse a space-separated file containing medium compound flux limits
+def parse_exchange_table_file(f):
+    """Parse a space-separated file containing exchange compound flux limits
 
     The first two columns contain compound IDs and compartment while the
     third column contains the lower flux limits. The fourth column is
@@ -743,7 +743,7 @@ def parse_medium_table_file(f):
             continue
 
         # A line can specify lower limit only (useful for
-        # exchange reactions), or both lower and upper limit.
+        # medium compounds), or both lower and upper limit.
         fields = line.split(None)
         if len(fields) < 2 or len(fields) > 4:
             raise ParseError('Malformed compound limit: {}'.format(fields))
@@ -759,8 +759,8 @@ def parse_medium_table_file(f):
         yield compound, None, lower, upper
 
 
-def parse_medium_file(path, default_compartment):
-    """Parse a file as a list of medium compounds with flux limits
+def parse_exchange_file(path, default_compartment):
+    """Parse a file as a list of exchange compounds with flux limits.
 
     The file format is detected and the file is parsed accordingly. Path can
     be given as a string or a context.
@@ -770,20 +770,20 @@ def parse_medium_file(path, default_compartment):
 
     format = resolve_format(None, context.filepath)
     if format == 'tsv':
-        logger.debug('Parsing medium file {} as TSV'.format(
+        logger.debug('Parsing exchange file {} as TSV'.format(
             context.filepath))
         with context.open('r') as f:
-            for entry in parse_medium_table_file(f):
+            for entry in parse_exchange_table_file(f):
                 yield entry
     elif format == 'yaml':
-        logger.debug('Parsing medium file {} as YAML'.format(
+        logger.debug('Parsing exchange file {} as YAML'.format(
             context.filepath))
         with context.open('r') as f:
-            for entry in parse_medium_yaml_file(
+            for entry in parse_exchange_yaml_file(
                     context, f, default_compartment):
                 yield entry
     else:
-        raise ParseError('Unable to detect format of medium file {}'.format(
+        raise ParseError('Unable to detect format of exchange file {}'.format(
             context.filepath))
 
 

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -294,6 +294,13 @@ class NativeModel(object):
                     compound = compound.in_compartment(extracellular)
                 yield compound, reaction_id, lower, upper
 
+    parse_medium = parse_exchange
+    """Yield tuples of exchange compounds.
+
+    .. deprecated:: 0.28
+       Use :meth:`parse_exchange` instead.
+    """
+
     def parse_compounds(self):
         """Yield CompoundEntries for defined compounds"""
 
@@ -698,6 +705,14 @@ def parse_exchange(exchange_def, default_compartment):
         yield compound, reaction, lower, upper
 
 
+parse_medium = parse_exchange
+"""Parse a structured exchange definition as obtained from a YAML file.
+
+.. deprecated:: 0.28
+   Use :func:`parse_exchange` instead.
+"""
+
+
 def parse_exchange_list(path, exchange, default_compartment):
     """Parse a structured exchange list as obtained from a YAML file.
 
@@ -719,6 +734,14 @@ def parse_exchange_list(path, exchange, default_compartment):
                 yield exchange_compound
 
 
+parse_medium_list = parse_exchange_list
+"""Parse a structured exchange list as obtained from a YAML file.
+
+.. deprecated:: 0.28
+   Use :func:`parse_exchange_list` instead.
+"""
+
+
 def parse_exchange_yaml_file(path, f, default_compartment):
     """Parse a file as a YAML-format exchange definition.
 
@@ -728,8 +751,16 @@ def parse_exchange_yaml_file(path, f, default_compartment):
     return parse_exchange(yaml_load(f), default_compartment)
 
 
+parse_medium_yaml_file = parse_exchange_yaml_file
+"""Parse a file as a YAML-format exchange definition.
+
+.. deprecated:: 0.28
+   Use :func:`parse_exchange_yaml_file` instead.
+"""
+
+
 def parse_exchange_table_file(f):
-    """Parse a space-separated file containing exchange compound flux limits
+    """Parse a space-separated file containing exchange compound flux limits.
 
     The first two columns contain compound IDs and compartment while the
     third column contains the lower flux limits. The fourth column is
@@ -759,6 +790,14 @@ def parse_exchange_table_file(f):
         yield compound, None, lower, upper
 
 
+parse_medium_table_file = parse_exchange_table_file
+"""Parse a space-separated file containing exchange compound flux limits.
+
+.. deprecated:: 0.28
+   Use :func:`parse_exchange_table_file` instead.
+"""
+
+
 def parse_exchange_file(path, default_compartment):
     """Parse a file as a list of exchange compounds with flux limits.
 
@@ -785,6 +824,14 @@ def parse_exchange_file(path, default_compartment):
     else:
         raise ParseError('Unable to detect format of exchange file {}'.format(
             context.filepath))
+
+
+parse_medium_file = parse_exchange_file
+"""Parse a file as a list of exchange compounds with flux limits.
+
+.. deprecated:: 0.28
+   Use :func:`parse_exchange_file` instead.
+"""
 
 
 def parse_limit(limit_def):

--- a/psamm/datasource/sbml.py
+++ b/psamm/datasource/sbml.py
@@ -849,7 +849,7 @@ class SBMLWriter(object):
         # Add exchange reactions to reaction_properties,
         # also add flux limit info to flux_limits
         flux_limits = {}
-        for compound, reaction_id, lower, upper in model.parse_medium():
+        for compound, reaction_id, lower, upper in model.parse_exchange():
             # Create exchange reaction
             if reaction_id is None:
                 reaction_id = create_exchange_id(reaction_properties, compound)

--- a/psamm/metabolicmodel.py
+++ b/psamm/metabolicmodel.py
@@ -279,9 +279,9 @@ class MetabolicModel(MetabolicDatabase):
         return model
 
     @classmethod
-    def load_model(cls, database, reaction_iter=None, medium=None, limits=None,
-                   v_max=None):
-        """Get model from reaction name iterator
+    def load_model(cls, database, reaction_iter=None, exchange=None,
+                   limits=None, v_max=None):
+        """Get model from reaction name iterator.
 
         The model will contain all reactions of the iterator.
         """
@@ -308,8 +308,8 @@ class MetabolicModel(MetabolicDatabase):
         # database and add it to the model. Ideally, we should not modify
         # the database. The exchange reaction could be created on the
         # fly when required.
-        if medium is not None:
-            for compound, reaction_id, lower, upper in medium:
+        if exchange is not None:
+            for compound, reaction_id, lower, upper in exchange:
                 # Create exchange reaction
                 if reaction_id is None:
                     reaction_id = create_exchange_id(

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -156,7 +156,7 @@ class TestCommandMain(unittest.TestCase):
                     'formula': 'O2'
                 }
             ],
-            'media': [
+            'exchange': [
                 {
                     'compartment': 'e',
                     'compounds': [

--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -511,8 +511,8 @@ class TestCommandMain(unittest.TestCase):
             ['C', '', '-1', 'O2', 'true']
         ])
 
-    def test_run_tableexport_medium(self):
-        f = self.run_command(ExportTableCommand, ['medium'])
+    def test_run_tableexport_exchange(self):
+        f = self.run_command(ExportTableCommand, ['exchange'])
 
         self.assertTableOutputEqual(f.getvalue(), [
             ['Compound ID', 'Reaction ID', 'Lower Limit', 'Upper Limit'],

--- a/psamm/tests/test_datasource_native.py
+++ b/psamm/tests/test_datasource_native.py
@@ -127,21 +127,22 @@ class TestYAMLDataSource(unittest.TestCase):
                 }
             ]))
 
-    def test_parse_medium_table(self):
+    def test_parse_exchange_table(self):
         table = '''
 ac      e
 glcD    e       -10
 co2     e       -       50
 '''
 
-        medium = list(native.parse_medium_table_file(StringIO(table.strip())))
-        self.assertEqual(len(medium), 3)
-        self.assertEqual(medium[0], (Compound('ac', 'e'), None, None, None))
-        self.assertEqual(medium[1], (Compound('glcD', 'e'), None, -10, None))
-        self.assertEqual(medium[2], (Compound('co2', 'e'), None, None, 50))
+        exchange = list(
+            native.parse_exchange_table_file(StringIO(table.strip())))
+        self.assertEqual(len(exchange), 3)
+        self.assertEqual(exchange[0], (Compound('ac', 'e'), None, None, None))
+        self.assertEqual(exchange[1], (Compound('glcD', 'e'), None, -10, None))
+        self.assertEqual(exchange[2], (Compound('co2', 'e'), None, None, 50))
 
-    def test_parse_medium(self):
-        medium = list(native.parse_medium({
+    def test_parse_exchange(self):
+        exchange = list(native.parse_exchange({
             'compartment': 'e',
             'compounds': [
                 {'id': 'ac'},
@@ -152,14 +153,14 @@ co2     e       -       50
             ]
         }, 'e'))
 
-        self.assertEqual(len(medium), 5)
-        self.assertEqual(medium[0], (Compound('ac', 'e'), None, None, None))
-        self.assertEqual(medium[1], (Compound('glcD', 'e'), None, -10, None))
-        self.assertEqual(medium[2], (Compound('co2', 'e'), None, None, 50))
+        self.assertEqual(len(exchange), 5)
+        self.assertEqual(exchange[0], (Compound('ac', 'e'), None, None, None))
+        self.assertEqual(exchange[1], (Compound('glcD', 'e'), None, -10, None))
+        self.assertEqual(exchange[2], (Compound('co2', 'e'), None, None, 50))
         self.assertEqual(
-            medium[3], (Compound('compound_x', 'c'), None, None, None))
+            exchange[3], (Compound('compound_x', 'c'), None, None, None))
         self.assertEqual(
-            medium[4], (Compound('compound_y', 'e'), 'EX_cpdy', None, None))
+            exchange[4], (Compound('compound_y', 'e'), 'EX_cpdy', None, None))
 
     def test_parse_normal_float(self):
         v = native.yaml_load('-23.456')
@@ -225,7 +226,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
             name: Test model
             biomass: rxn_1
             reactions:
-              - include: medium.yaml
+              - include: exchange.yaml
             '''
         m = native.NativeModel(longString)
         with self.assertRaises(context.ContextError):
@@ -304,9 +305,9 @@ class TestYAMLFileSystemData(unittest.TestCase):
 
         model = native.NativeModel.load_model_from_path(path)
 
-        medium = list(model.parse_medium())
-        self.assertEqual(medium[0][0], Compound('A', 'Ex'))
-        self.assertEqual(medium[1][0], Compound('B', 'c'))
+        exchange = list(model.parse_exchange())
+        self.assertEqual(exchange[0][0], Compound('A', 'Ex'))
+        self.assertEqual(exchange[1][0], Compound('B', 'c'))
 
     def test_parse_model_file_with_media(self):
         """Test parsing model with the deprecated media key."""
@@ -321,9 +322,9 @@ class TestYAMLFileSystemData(unittest.TestCase):
 
         model = native.NativeModel.load_model_from_path(path)
 
-        medium = list(model.parse_medium())
-        self.assertEqual(medium[0][0], Compound('A', 'Ex'))
-        self.assertEqual(medium[1][0], Compound('B', 'c'))
+        exchange = list(model.parse_exchange())
+        self.assertEqual(exchange[0][0], Compound('A', 'Ex'))
+        self.assertEqual(exchange[1][0], Compound('B', 'c'))
 
     def test_parse_model_file_with_media_and_exchange(self):
         """Test that parsing model with both media and exchange fails."""
@@ -343,7 +344,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
         model = native.NativeModel.load_model_from_path(path)
 
         with self.assertRaises(native.ParseError):
-            medium = list(model.parse_medium())
+            medium = list(model.parse_exchange())
 
     def test_parse_compound_tsv_file(self):
         path = self.write_model_file('compounds.tsv', '\n'.join([
@@ -426,8 +427,8 @@ class TestYAMLFileSystemData(unittest.TestCase):
         self.assertEqual(reactions[0].id, 'rxn_1')
         self.assertEqual(reactions[1].id, 'rxn_2')
 
-    def test_parse_medium_table_file(self):
-        path = self.write_model_file('medium.tsv', '\n'.join([
+    def test_parse_exchange_table_file(self):
+        path = self.write_model_file('exchange.tsv', '\n'.join([
             '',
             '# comment',
             'cpd_A\tc',
@@ -436,8 +437,8 @@ class TestYAMLFileSystemData(unittest.TestCase):
             'cpd_D\te\t-100\t-10'
         ]))
 
-        medium = list(native.parse_medium_file(path, 'e'))
-        self.assertEqual(medium, [
+        exchange = list(native.parse_exchange_file(path, 'e'))
+        self.assertEqual(exchange, [
             (Compound('cpd_A', 'c'), None, None, None),
             (Compound('cpd_B', 'e'), None, -1000, None),
             (Compound('cpd_C', 'e'), None, None, 20),
@@ -452,8 +453,8 @@ class TestYAMLFileSystemData(unittest.TestCase):
         with self.assertRaises(native.ParseError):
             native.get_limits(d)
 
-    def test_parse_medium_yaml_file(self):
-        path = self.write_model_file('medium.yaml', '\n'.join([
+    def test_parse_exchange_yaml_file(self):
+        path = self.write_model_file('exchange.yaml', '\n'.join([
             'compartment: e',
             'compounds:',
             '  - id: cpd_A',
@@ -470,8 +471,8 @@ class TestYAMLFileSystemData(unittest.TestCase):
             '    fixed: 100.0',
         ]))
 
-        medium = list(native.parse_medium_file(path, 'e'))
-        self.assertEqual(medium, [
+        exchange = list(native.parse_exchange_file(path, 'e'))
+        self.assertEqual(exchange, [
             (Compound('cpd_A', 'e'), 'EX_A', -40, None),
             (Compound('cpd_B', 'e'), None, None, 100),
             (Compound('cpd_C', 'e'), None, -100, 500),
@@ -479,8 +480,8 @@ class TestYAMLFileSystemData(unittest.TestCase):
             (Compound('cpd_E', 'e'), None, 100, 100)
         ])
 
-    def test_parse_medium_yaml_list(self):
-        self.write_model_file('medium.yaml', '\n'.join([
+    def test_parse_exchange_yaml_list(self):
+        self.write_model_file('exchange.yaml', '\n'.join([
             'compartment: e',
             'compounds:',
             '  - id: cpd_A',
@@ -488,8 +489,8 @@ class TestYAMLFileSystemData(unittest.TestCase):
         ]))
 
         path = os.path.join(self._model_dir, 'fake.yaml')
-        medium = list(native.parse_medium_list(path, [
-            {'include': 'medium.yaml'},
+        exchange = list(native.parse_exchange_list(path, [
+            {'include': 'exchange.yaml'},
             {
                 'compartment': 'e',
                 'compounds': [
@@ -498,7 +499,7 @@ class TestYAMLFileSystemData(unittest.TestCase):
             }
         ], 'e'))
 
-        self.assertEqual(medium, [
+        self.assertEqual(exchange, [
             (Compound('cpd_A', 'e'), None, -42, None),
             (Compound('cpd_B', 'e'), None, None, 767)
         ])

--- a/psamm/tests/test_gapfilling.py
+++ b/psamm/tests/test_gapfilling.py
@@ -97,7 +97,7 @@ class TestCreateExtendedModel(unittest.TestCase):
                 {'id': 'C'},
                 {'id': 'D'}
             ],
-            'media': [{
+            'exchange': [{
                 'compartment': 'e',
                 'compounds': [
                     {

--- a/psamm/tests/test_randomsparse.py
+++ b/psamm/tests/test_randomsparse.py
@@ -54,7 +54,7 @@ class TestGetGeneAssociation(unittest.TestCase):
                 '  - id: B',
                 '  - id: C',
                 '  - id: D',
-                'media:',
+                'exchange:',
                 '  - compartment: e',
                 '    compounds:',
                 '      - id: A',


### PR DESCRIPTION
Rename the "media" key in the model file to "exchange" reflecting the fact that it specifies both compounds with allowed uptake (the medium) and compounds allowed to exit the model system. Also introduces related changes in `tableexport` and `excelexport` commands.

The old "media" key is still parsed in the model files but is deprecated and a warning is produced if it is present. The "medium" command in `tableexport` still works but the same command can also be run be specifying "exchange".

Documentation on the file format and tutorial is updated with this change.

- [x] Update `psamm-import` to use the new key (https://github.com/zhanglab/psamm-import/pull/35) (and import medium and exchange compounds to separate files?)
- [x] Update tutorial repository (https://github.com/zhanglab/psamm-tutorial/pull/1).