### PR TITLE
excelexport: Mention name of Python package in error message

### DIFF
--- a/psamm/commands/excelexport.py
+++ b/psamm/commands/excelexport.py
@@ -45,7 +45,10 @@ class ExcelExportCommand(Command):
     def run(self):
         model = self._model
         if xlsxwriter is None:
-            self.fail('Excel export requires the XlsxWriter python module')
+            self.fail(
+                'Excel export requires the XlsxWriter python module'
+                ' ("pip install xlsxwriter")')
+
         workbook = xlsxwriter.Workbook(self._args.file)
         reaction_sheet = workbook.add_worksheet(name='Reactions')
 


### PR DESCRIPTION
When excelexport fails due to missing xlsxwriter, include the
pip command line to install the package in the error message.