### PR TITLE
Add command to operate on SBML files directly

### DIFF
--- a/psamm/command.py
+++ b/psamm/command.py
@@ -40,7 +40,8 @@ import pkg_resources
 from six import add_metaclass, iteritems, itervalues, text_type
 
 from . import __version__ as package_version
-from .datasource import native
+from .datasource import native, sbml
+from .datasource.context import FilePathContext
 from .lpsolver import generic
 
 logger = logging.getLogger(__name__)
@@ -547,10 +548,83 @@ def main(command_class=None, args=None):
     parsed_args = parser.parse_args(args)
 
     # Load model definition
-    reader = native.ModelReader.reader_from_path(parsed_args.model)
+    model = native.ModelReader.reader_from_path(
+        parsed_args.model).create_model()
 
     # Instantiate command with model and run
-    command = parsed_args.command(reader.create_model(), parsed_args)
+    command = parsed_args.command(model, parsed_args)
+    try:
+        command.run()
+    except CommandError as e:
+        parser.error(text_type(e))
+
+
+def main_sbml(command_class=None, args=None):
+    # Set up logging for the command line interface
+    if 'PSAMM_DEBUG' in os.environ:
+        level = getattr(logging, os.environ['PSAMM_DEBUG'].upper(), None)
+        if level is not None:
+            logging.basicConfig(level=level)
+    else:
+        logging.basicConfig(level=logging.INFO)
+        base_logger = logging.getLogger('psamm')
+        if len(base_logger.handlers) == 0:
+            handler = logging.StreamHandler()
+            handler.setFormatter(
+                logging.Formatter(u'%(levelname)s: %(message)s'))
+            base_logger.addHandler(handler)
+            base_logger.propagate = False
+
+    logger.warning(
+        'This command is experimental. It currently only fully parses level 3'
+        ' SBML files!')
+
+    title = 'Metabolic modeling tools (SBML)'
+    if command_class is not None:
+        title, _, _ = command_class.__doc__.partition('\n\n')
+
+    parser = argparse.ArgumentParser(description=title)
+    parser.add_argument('model', metavar='file', help='SBML file')
+    parser.add_argument(
+        '-V', '--version', action='version',
+        version='%(prog)s ' + package_version)
+
+    if command_class is not None:
+        # Command explicitly given, only allow that command
+        command_class.init_parser(parser)
+        parser.set_defaults(command=command_class)
+    else:
+        # Discover all available commands
+        commands = {}
+        for entry in pkg_resources.iter_entry_points('psamm.commands'):
+            canonical = entry.name.lower()
+            if canonical not in commands:
+                command_class = entry.load()
+                commands[canonical] = command_class
+            else:
+                logger.warning('Command {} was found more than once!'.format(
+                    canonical))
+
+        # Create parsers for subcommands
+        subparsers = parser.add_subparsers(title='Commands', metavar='command')
+        for name, command_class in sorted(iteritems(commands)):
+            title, _, _ = command_class.__doc__.partition('\n\n')
+            subparser = subparsers.add_parser(
+                name, help=title.rstrip('.'),
+                formatter_class=argparse.RawDescriptionHelpFormatter,
+                description=_trim(command_class.__doc__))
+            subparser.set_defaults(command=command_class)
+            command_class.init_parser(subparser)
+
+    parsed_args = parser.parse_args(args)
+
+    # Load model definition
+    context = FilePathContext(parsed_args.model)
+    with context.open('r') as f:
+        model = sbml.SBMLReader(f, context=context).create_model()
+
+    # Instantiate command with model and run
+    command = parsed_args.command(model, parsed_args)
     try:
         command.run()
     except CommandError as e:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 from setuptools import setup, find_packages
 
@@ -47,6 +47,7 @@ setup(
     entry_points = {
         'console_scripts': [
             'psamm-model = psamm.command:main',
+            'psamm-sbml-model = psamm.command:main_sbml',
             'psamm-list-lpsolvers = psamm.lpsolver.generic:list_solvers'
         ],
         'psamm.commands': [


### PR DESCRIPTION
Add command `psamm-sbml-model` to run any command directly on an SBML file. Since this is using the `SBMLReader` in `psamm.datasource.sbml` it only supports the standardized SBML format and does not yet support alternative data such as COBRA-specific encodings of objective, flux bounds, gene associations etc. that are common in level 1 and 2 files.