### PR TITLE
By default, ignore boundary species in SBMLReader

### DIFF
--- a/psamm/datasource/sbml.py
+++ b/psamm/datasource/sbml.py
@@ -538,9 +538,18 @@ class SBMLReader(object):
     If ``ignore_boundary`` is ``True``, the species that are marked as
     boundary conditions will simply be dropped from the species list and from
     the reaction equations, and any boundary compartment will be dropped too.
+    Otherwise the boundary species will be retained. Retaining these is only
+    useful to extract specific information from those species objects.
+
+    Args:
+        file: File-like object to parse XML SBML content from.
+        strict: Indicating whether strict parsing is enabled.
+        ignore_boundary: Indicating whether boundary species are dropped.
+        context: Optional file parsing context from
+            :mod:`psamm.datasource.context`.
     """
 
-    def __init__(self, file, strict=False, ignore_boundary=False,
+    def __init__(self, file, strict=False, ignore_boundary=True,
                  context=None):
         # Parse SBML file
         tree = ET.parse(file)

--- a/psamm/datasource/sbml.py
+++ b/psamm/datasource/sbml.py
@@ -841,7 +841,7 @@ class SBMLReader(object):
 
 
 class SBMLWriter(object):
-    """Writer of SBML files"""
+    """Writer of SBML files."""
 
     def __init__(self, cobra_flux_bounds=False):
         self._namespace = SBML_NS_L3_V1_CORE
@@ -979,8 +979,13 @@ class SBMLWriter(object):
                 elem.tail = i
 
     def write_model(self, file, model, pretty=False):
-        """Write a given model to file"""
+        """Write a given model to file.
 
+        Args:
+            file: File-like object open for writing.
+            model: Instance of :class:`NativeModel` to write.
+            pretty: Whether to format the XML output for readability.
+        """
         ET.register_namespace('mathml', MATHML_NS)
         ET.register_namespace('xhtml', XHTML_NS)
         ET.register_namespace('fbc', FBC_V2)

--- a/psamm/tests/test_datasource_sbml.py
+++ b/psamm/tests/test_datasource_sbml.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 import unittest
 
@@ -77,7 +77,7 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
         self.assertEqual(reader.name, 'Test model')
 
     def test_compartment_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         compartments = {entry.id: entry for entry in reader.compartments}
         self.assertEqual(len(compartments), 2)
         self.assertEqual(compartments['cell'].id, 'cell')
@@ -93,7 +93,7 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
         self.assertEqual(compartments['cell'].name, 'cell')
 
     def test_compounds_exist(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
@@ -132,7 +132,7 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_biomass_reaction_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         reaction = reader.get_reaction('Biomass')
         self.assertFalse(reaction.reversible)
 
@@ -144,7 +144,7 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_reaction_xml_notes(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         reaction = reader.get_reaction('G6Pase')
         notes = reaction.xml_notes
 
@@ -217,7 +217,7 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
         self.assertEqual(reader.name, 'Test model')
 
     def test_compartment_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         compartments = {entry.id: entry for entry in reader.compartments}
         self.assertEqual(len(compartments), 2)
         self.assertEqual(compartments['C_c'].id, 'C_c')
@@ -233,7 +233,7 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
         self.assertEqual(compartments['C_c'].name, 'cell')
 
     def test_compounds_exist(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
@@ -272,7 +272,7 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_biomass_reaction_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         reaction = reader.get_reaction('R_Biomass')
         self.assertFalse(reaction.reversible)
 
@@ -357,7 +357,7 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         self.assertEqual(reader.name, 'Test model')
 
     def test_compartment_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         compartments = {entry.id: entry for entry in reader.compartments}
         self.assertEqual(len(compartments), 2)
         self.assertEqual(compartments['C_c'].id, 'C_c')
@@ -373,7 +373,7 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         self.assertEqual(compartments['C_c'].name, 'cell')
 
     def test_compounds_exist(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
@@ -409,7 +409,7 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_biomass_reaction_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         reaction = reader.get_reaction('R_Biomass')
         self.assertFalse(reaction.reversible)
 
@@ -506,7 +506,7 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
         self.assertEqual(reader.name, 'Test model')
 
     def test_compartment_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         compartments = {entry.id: entry for entry in reader.compartments}
         self.assertEqual(len(compartments), 2)
         self.assertEqual(compartments['C_c'].id, 'C_c')
@@ -515,7 +515,7 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
         self.assertEqual(compartments['C_b'].name, 'boundary')
 
     def test_compounds_exist(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
@@ -547,7 +547,7 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
         self.assertIsNone(species['M_Biomass'].charge)
 
     def test_g6pase_reaction_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         reaction = reader.get_reaction('R_G6Pase')
         self.assertTrue(reaction.reversible)
 
@@ -563,7 +563,7 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
         self.assertEqual(reaction.properties['upper_flux'], 1000)
 
     def test_biomass_reaction_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         reaction = reader.get_reaction('R_Biomass')
         self.assertFalse(reaction.reversible)
 
@@ -675,7 +675,7 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
         self.assertEqual(reader.name, 'Test model')
 
     def test_compartment_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         compartments = {entry.id: entry for entry in reader.compartments}
         self.assertEqual(len(compartments), 2)
         self.assertEqual(compartments['C_c'].id, 'C_c')
@@ -684,7 +684,7 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
         self.assertEqual(compartments['C_b'].name, 'boundary')
 
     def test_compounds_exist(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
@@ -732,7 +732,7 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
         self.assertEqual(reaction.properties['upper_flux'], 1000)
 
     def test_biomass_reaction_exists(self):
-        reader = sbml.SBMLReader(self.doc)
+        reader = sbml.SBMLReader(self.doc, ignore_boundary=False)
         reaction = reader.get_reaction('R_Biomass')
         self.assertFalse(reaction.reversible)
 


### PR DESCRIPTION
Changes `SBMLReader` to ignore boundary species by default. This fixes a bug where the `psamm-sbml-model` command would include the boundary species in the model when running commands. This also makes it easier to use `SBMLReader` for the typical tasks of loading SBML files and creating models using `create_model()`.