### PR TITLE
Perform additional SBML model conversions

### DIFF
--- a/psamm/command.py
+++ b/psamm/command.py
@@ -560,6 +560,7 @@ def main(command_class=None, args=None):
 
 
 def main_sbml(command_class=None, args=None):
+    """Run the SBML command line interface."""
     # Set up logging for the command line interface
     if 'PSAMM_DEBUG' in os.environ:
         level = getattr(logging, os.environ['PSAMM_DEBUG'].upper(), None)
@@ -574,10 +575,6 @@ def main_sbml(command_class=None, args=None):
                 logging.Formatter(u'%(levelname)s: %(message)s'))
             base_logger.addHandler(handler)
             base_logger.propagate = False
-
-    logger.warning(
-        'This command is experimental. It currently only fully parses level 3'
-        ' SBML files!')
 
     title = 'Metabolic modeling tools (SBML)'
     if command_class is not None:
@@ -622,6 +619,7 @@ def main_sbml(command_class=None, args=None):
     context = FilePathContext(parsed_args.model)
     with context.open('r') as f:
         model = sbml.SBMLReader(f, context=context).create_model()
+        sbml.convert_sbml_model(model)
 
     # Instantiate command with model and run
     command = parsed_args.command(model, parsed_args)

--- a/psamm/command.py
+++ b/psamm/command.py
@@ -582,6 +582,9 @@ def main_sbml(command_class=None, args=None):
 
     parser = argparse.ArgumentParser(description=title)
     parser.add_argument('model', metavar='file', help='SBML file')
+    parser.add_argument('--merge-compounds', action='store_true',
+                        help=('Merge identical compounds occuring in various'
+                              ' compartments.'))
     parser.add_argument(
         '-V', '--version', action='version',
         version='%(prog)s ' + package_version)
@@ -620,6 +623,8 @@ def main_sbml(command_class=None, args=None):
     with context.open('r') as f:
         model = sbml.SBMLReader(f, context=context).create_model()
         sbml.convert_sbml_model(model)
+        if parsed_args.merge_compounds:
+            sbml.merge_equivalent_compounds(model)
 
     # Instantiate command with model and run
     command = parsed_args.command(model, parsed_args)

--- a/psamm/datasource/entry.py
+++ b/psamm/datasource/entry.py
@@ -134,6 +134,7 @@ class _BaseDictEntry(ModelEntry):
         else:
             raise ValueError('Invalid type of properties object')
 
+        self._properties['id'] = self._id
         self._filemark = filemark
 
     @property

--- a/psamm/datasource/native.py
+++ b/psamm/datasource/native.py
@@ -460,30 +460,54 @@ class NativeModel(object):
         """Return model name property."""
         return self._properties.get('name')
 
+    @name.setter
+    def name(self, value):
+        self._properties['name'] = value
+
     @property
     def version_string(self):
         """Return model version string."""
         return self._properties.get('version_string')
+
+    @version_string.setter
+    def version_string(self, value):
+        self._properties['version_string'] = value
 
     @property
     def biomass_reaction(self):
         """Return biomass reaction property."""
         return self._properties.get('biomass')
 
+    @biomass_reaction.setter
+    def biomass_reaction(self, value):
+        self._properties['biomass'] = value
+
     @property
     def extracellular_compartment(self):
         """Return extracellular compartment property."""
         return self._properties.get('extracellular')
+
+    @extracellular_compartment.setter
+    def extracellular_compartment(self, value):
+        self._properties['extracellular'] = value
 
     @property
     def default_compartment(self):
         """Return default compartment property."""
         return self._properties.get('default_compartment')
 
+    @default_compartment.setter
+    def default_compartment(self, value):
+        self._properties['default_compartment'] = value
+
     @property
     def default_flux_limit(self):
         """Return default flux limit property."""
         return self._properties.get('default_flux_limit')
+
+    @default_flux_limit.setter
+    def default_flux_limit(self, value):
+        self._properties['default_flux_limit'] = value
 
     @property
     def compartments(self):

--- a/psamm/datasource/sbml.py
+++ b/psamm/datasource/sbml.py
@@ -25,6 +25,7 @@ from functools import partial
 import logging
 import re
 import json
+from collections import OrderedDict
 
 # Import ElementTree XML parser. The lxml etree implementation may also be
 # used with SBMLReader but has compatiblity issues with SBMLWriter.
@@ -1649,3 +1650,130 @@ def parse_flux_bounds(entry):
             lower_bound = value
 
     return lower_bound, upper_bound
+
+
+def merge_equivalent_compounds(model):
+    """Merge equivalent compounds in various compartments.
+
+    Tries to detect and merge compound entries that represent the same
+    compound in different compartments. The entries are only merged if all
+    properties are equivalent. Compound entries must have an ID with a suffix
+    of an underscore followed by the compartment ID. This suffix will be
+    stripped and compounds with identical IDs are merged if the properties
+    are identical.
+
+    Args:
+        model: :class:`NativeModel`.
+    """
+    def dicts_are_compatible(d1, d2):
+        return all(key not in d1 or key not in d2 or d1[key] == d2[key]
+                   for key in set(d1) | set(d2))
+
+    compound_compartment = {}
+    inelegible = set()
+    for reaction in model.reactions:
+        equation = reaction.equation
+        if equation is None:
+            continue
+
+        for compound, _ in equation.compounds:
+            compartment = compound.compartment
+            if compartment is not None:
+                compound_compartment[compound.name] = compartment
+                if not compound.name.endswith('_{}'.format(compartment)):
+                    inelegible.add(compound.name)
+
+    compound_groups = {}
+    for compound_id, compartment in iteritems(compound_compartment):
+        if compound_id in inelegible:
+            continue
+
+        suffix = '_{}'.format(compound_compartment[compound_id])
+        if compound_id.endswith(suffix):
+            group_name = compound_id[:-len(suffix)]
+            compound_groups.setdefault(group_name, set()).add(compound_id)
+
+    compound_mapping = {}
+    merged_compounds = {}
+    for group, compound_set in iteritems(compound_groups):
+        # Try to merge as many compounds as possible
+        merged = []
+        for compound_id in compound_set:
+            props = dict(model.compounds[compound_id].properties)
+
+            # Ignore differences in ID and compartment properties
+            props.pop('id', None)
+            props.pop('compartment', None)
+
+            for merged_props, merged_set in merged:
+                if dicts_are_compatible(props, merged_props):
+                    merged_set.add(compound_id)
+                    merged_props.update(props)
+                    break
+                else:
+                    keys = set(key for key in set(props) | set(merged_props)
+                               if key not in props or
+                               key not in merged_props or
+                               props[key] != merged_props[key])
+                    logger.info(
+                        'Unable to merge {} into {}, difference in'
+                        ' keys: {}'.format(
+                            compound_id, ', '.join(merged_set),
+                            ', '.join(keys)))
+            else:
+                merged.append((props, {compound_id}))
+
+        if len(merged) == 1:
+            # Merge into one set with the group name
+            merged_props, merged_set = merged[0]
+
+            for compound_id in merged_set:
+                compound_mapping[compound_id] = group
+            merged_compounds[group] = merged_props
+        else:
+            # Since we cannot merge all compounds, create new group names
+            # based on the group and compartments.
+            for merged_props, merged_set in merged:
+                compartments = set(compound_compartment[c] for c in merged_set)
+                merged_name = '{}_{}'.format(
+                    group, '_'.join(sorted(compartments)))
+
+                for compound_id in merged_set:
+                    compound_mapping[compound_id] = merged_name
+                merged_compounds[merged_name] = merged_props
+
+    # Translate reaction compounds
+    for reaction in model.reactions:
+        equation = reaction.equation
+        if equation is None:
+            continue
+
+        reaction.equation = equation.translated_compounds(
+            lambda c: compound_mapping.get(c, c))
+
+    # Translate compound entries
+    new_compounds = []
+    for compound in model.compounds:
+        if compound.id not in compound_mapping:
+            new_compounds.append(compound)
+        else:
+            group = compound_mapping[compound.id]
+            if group not in merged_compounds:
+                continue
+            props = merged_compounds.pop(group)
+            props['id'] = group
+            new_compounds.append(DictCompoundEntry(
+                props, filemark=compound.filemark))
+
+    model.compounds.clear()
+    model.compounds.update(new_compounds)
+
+    # Translate exchange
+    new_exchange = OrderedDict()
+    for compound, reaction_id, lower, upper in itervalues(model.exchange):
+        new_compound = compound.translate(
+            lambda name: compound_mapping.get(name, name))
+        new_exchange[new_compound] = new_compound, reaction_id, lower, upper
+
+    model.exchange.clear()
+    model.exchange.update(new_exchange)

--- a/psamm/datasource/sbml.py
+++ b/psamm/datasource/sbml.py
@@ -828,6 +828,10 @@ class SBMLReader(object):
         for reaction in self.reactions:
             model.reactions.add_entry(reaction)
 
+        # Create model reaction set
+        for reaction in model.reactions:
+            model.model[reaction.id] = None
+
         # Convert reaction limits properties to proper limits
         for reaction in model.reactions:
             props = reaction.properties

--- a/psamm/tests/test_datasource_entry.py
+++ b/psamm/tests/test_datasource_entry.py
@@ -58,10 +58,13 @@ class TestDictEntries(unittest.TestCase):
 
     def test_create_compound_dict_entry_with_id_override(self):
         props = {
+            'id': 'old_id',
             'name': 'Compound 1',
             'formula': 'CO2'
         }
         e = entry.DictCompoundEntry(props, id='new_id')
+        self.assertEqual(e.id, 'new_id')
+        self.assertEqual(e.properties['id'], 'new_id')
 
     def test_use_compound_dict_entry_setters(self):
         e = entry.DictCompoundEntry({}, id='new_id')

--- a/psamm/tests/test_datasource_native.py
+++ b/psamm/tests/test_datasource_native.py
@@ -680,6 +680,23 @@ class TestCheckId(unittest.TestCase):
         native._check_id(u'\u222b', 'Compound')
 
 
+class TestNativeModel(unittest.TestCase):
+    def test_properties(self):
+        model = native.NativeModel()
+        model.name = 'Test model'
+        model.version_string = '1.0'
+        model.biomass_reaction = 'rxn_1'
+        model.extracellular_compartment = 'e'
+        model.default_compartment = 'c'
+        model.default_flux_limit = 1000
+        self.assertEqual(model.name, 'Test model')
+        self.assertEqual(model.version_string, '1.0')
+        self.assertEqual(model.biomass_reaction, 'rxn_1')
+        self.assertEqual(model.extracellular_compartment, 'e')
+        self.assertEqual(model.default_compartment, 'c')
+        self.assertEqual(model.default_flux_limit, 1000)
+
+
 class TestNativeModelWriter(unittest.TestCase):
     def setUp(self):
         self.writer = native.ModelWriter()

--- a/psamm/tests/test_datasource_sbml.py
+++ b/psamm/tests/test_datasource_sbml.py
@@ -224,6 +224,14 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
     <listOfProducts>
      <speciesReference species="M_Biomass"/>
     </listOfProducts>
+    <kineticLaw>
+     <listOfParameters>
+      <parameter id="LOWER_BOUND" value="0"/>
+      <parameter id="UPPER_BOUND" value="1000"/>
+      <parameter id="SOME_CUSTOM_PARAMETER" value="123.4"/>
+      <parameter id="OBJECTIVE_COEFFICIENT" value="1"/>
+     </listOfParameters>
+    </kineticLaw>
    </reaction>
   </listOfReactions>
  </model>
@@ -310,6 +318,28 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
             'confidence': 3,
             'authors': ['Jane Doe', 'John Doe']
         })
+
+    def test_parse_reaction_cobra_flux_bounds(self):
+        reader = sbml.SBMLReader(self.doc)
+        reaction = reader.get_reaction('R_G6Pase')
+        lower, upper = sbml.parse_flux_bounds(reaction)
+        self.assertIsNone(lower)
+        self.assertIsNone(upper)
+
+        reaction = reader.get_reaction('R_Biomass')
+        lower, upper = sbml.parse_flux_bounds(reaction)
+        self.assertEqual(lower, 0)
+        self.assertEqual(upper, 1000)
+
+    def test_parse_reaction_cobra_objective(self):
+        reader = sbml.SBMLReader(self.doc)
+        reaction = reader.get_reaction('R_G6Pase')
+        coeff = sbml.parse_objective_coefficient(reaction)
+        self.assertIsNone(coeff)
+
+        reaction = reader.get_reaction('R_Biomass')
+        coeff = sbml.parse_objective_coefficient(reaction)
+        self.assertEqual(coeff, 1)
 
     def test_biomass_reaction_exists(self):
         reader = sbml.SBMLReader(self.doc, ignore_boundary=False)

--- a/psamm/tests/test_datasource_sbml.py
+++ b/psamm/tests/test_datasource_sbml.py
@@ -42,11 +42,15 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
    <compartment name="cell"/>
   </listOfCompartments>
   <listOfSpecies>
-   <species name="Glucose" compartment="cell" initialAmount="1" charge="0"/>
-   <species name="Glucose_6_P" compartment="cell" initialAmount="1" charge="-2"/>
+   <species name="Glucose" compartment="cell" initialAmount="1"
+            charge="0"/>
+   <species name="Glucose_6_P" compartment="cell" initialAmount="1"
+            charge="-2"/>
    <species name="H2O" compartment="cell" initialAmount="1" charge="0"/>
-   <species name="Phosphate" compartment="cell" initialAmount="1" boundaryCondition="false"/>
-   <species name="Biomass" compartment="boundary" initialAmount="1" boundaryCondition="true"/>
+   <species name="Phosphate" compartment="cell" initialAmount="1"
+            boundaryCondition="false"/>
+   <species name="Biomass" compartment="boundary" initialAmount="1"
+            boundaryCondition="true"/>
   </listOfSpecies>
   <listOfReactions>
    <reaction name="G6Pase" reversible="true">
@@ -64,7 +68,8 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
    </reaction>
    <reaction name="Biomass" reversible="false">
     <listOfReactants>
-     <speciesReference species="Glucose_6_P" stoichiometry="56" denominator="100"/>
+     <speciesReference species="Glucose_6_P" stoichiometry="56"
+                       denominator="100"/>
     </listOfReactants>
     <listOfProducts>
      <speciesReference species="Biomass"/>
@@ -166,6 +171,21 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
         flux_bounds = list(reader.flux_bounds)
         self.assertEqual(len(flux_bounds), 0)
 
+    def test_create_and_convert_model(self):
+        reader = sbml.SBMLReader(self.doc)
+        model = reader.create_model()
+        sbml.convert_sbml_model(model)
+
+        self.assertEqual(
+            {entry.id for entry in model.compounds},
+            {'Glucose', 'Glucose_6_P', 'H2O', 'Phosphate'})
+        self.assertEqual(
+            {entry.id for entry in model.reactions},
+            {'G6Pase', 'Biomass'})
+        self.assertEqual(
+            {entry.id for entry in model.compartments},
+            {'cell'})
+
 
 class TestSBMLDatabaseL2V5(unittest.TestCase):
     """Test parsing of a simple level 2 version 5 SBML file"""
@@ -180,7 +200,8 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
    <compartment id="C_b" name="boundary"/>
   </listOfCompartments>
   <listOfSpecies>
-   <species id="M_Glucose" name="Glucose" compartment="C_c" charge="0">
+   <species id="M_Glucose_LPAREN_c_RPAREN_" name="Glucose" compartment="C_c"
+            charge="0">
     <notes>
      <body xmlns="http://www.w3.org/1999/xhtml">
       <p>FORMULA: C6H12O6</p>
@@ -191,20 +212,26 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
      </body>
     </notes>
    </species>
-   <species id="M_Glucose_6_P" name="Glucose-6-P" compartment="C_c" charge="-2"/>
-   <species id="M_H2O" name="H2O" compartment="C_c" charge="0"/>
-   <species id="M_Phosphate" name="Phosphate" compartment="C_c" boundaryCondition="false"/>
-   <species id="M_Biomass" name="Biomass" compartment="C_b" boundaryCondition="true"/>
+   <species id="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_" name="Glucose-6-P"
+            compartment="C_c" charge="-2"/>
+   <species id="M_H2O_LPAREN_c_RPAREN_" name="H2O" compartment="C_c"
+            charge="0"/>
+   <species id="M_Phosphate_LPAREN_c_RPAREN_" name="Phosphate"
+            compartment="C_c" boundaryCondition="false"/>
+   <species id="M_Biomass" name="Biomass" compartment="C_b"
+            boundaryCondition="true"/>
   </listOfSpecies>
   <listOfReactions>
    <reaction id="R_G6Pase" reversible="true">
     <listOfReactants>
-     <speciesReference species="M_Glucose" stoichiometry="2"/>
-     <speciesReference species="M_Phosphate" stoichiometry="2"/>
+     <speciesReference species="M_Glucose_LPAREN_c_RPAREN_" stoichiometry="2"/>
+     <speciesReference species="M_Phosphate_LPAREN_c_RPAREN_"
+                       stoichiometry="2"/>
     </listOfReactants>
     <listOfProducts>
-     <speciesReference species="M_H2O" stoichiometry="2"/>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="2"/>
+     <speciesReference species="M_H2O_LPAREN_c_RPAREN_" stoichiometry="2"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="2"/>
     </listOfProducts>
     <notes>
      <body xmlns="http://www.w3.org/1999/xhtml">
@@ -219,7 +246,8 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
    </reaction>
    <reaction id="R_Biomass" reversible="false">
     <listOfReactants>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="0.56"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="0.56"/>
     </listOfReactants>
     <listOfProducts>
      <speciesReference species="M_Biomass"/>
@@ -263,30 +291,33 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
-        self.assertEqual(species['M_Glucose'].id, 'M_Glucose')
-        self.assertEqual(species['M_Glucose'].name, 'Glucose')
-        self.assertEqual(species['M_Glucose'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose'].boundary)
-        self.assertEqual(species['M_Glucose'].charge, 0)
+        gluc_species = species['M_Glucose_LPAREN_c_RPAREN_']
+        self.assertEqual(gluc_species.id, 'M_Glucose_LPAREN_c_RPAREN_')
+        self.assertEqual(gluc_species.name, 'Glucose')
+        self.assertEqual(gluc_species.compartment, 'C_c')
+        self.assertFalse(gluc_species.boundary)
+        self.assertEqual(gluc_species.charge, 0)
 
-        self.assertEqual(species['M_Glucose_6_P'].id, 'M_Glucose_6_P')
-        self.assertEqual(species['M_Glucose_6_P'].name, 'Glucose-6-P')
-        self.assertEqual(species['M_Glucose_6_P'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose_6_P'].boundary)
-        self.assertEqual(species['M_Glucose_6_P'].charge, -2)
+        g6p_species = species['M_Glucose_6_DASH_P_LPAREN_c_RPAREN_']
+        self.assertEqual(g6p_species.id, 'M_Glucose_6_DASH_P_LPAREN_c_RPAREN_')
+        self.assertEqual(g6p_species.name, 'Glucose-6-P')
+        self.assertEqual(g6p_species.compartment, 'C_c')
+        self.assertFalse(g6p_species.boundary)
+        self.assertEqual(g6p_species.charge, -2)
 
-        self.assertEqual(species['M_H2O'].id, 'M_H2O')
-        self.assertEqual(species['M_H2O'].name, 'H2O')
-        self.assertEqual(species['M_H2O'].compartment, 'C_c')
-        self.assertFalse(species['M_H2O'].boundary)
-        self.assertEqual(species['M_H2O'].charge, 0)
+        h2o_species = species['M_H2O_LPAREN_c_RPAREN_']
+        self.assertEqual(h2o_species.id, 'M_H2O_LPAREN_c_RPAREN_')
+        self.assertEqual(h2o_species.name, 'H2O')
+        self.assertEqual(h2o_species.compartment, 'C_c')
+        self.assertFalse(h2o_species.boundary)
+        self.assertEqual(h2o_species.charge, 0)
 
-        self.assertFalse(species['M_Phosphate'].boundary)
+        self.assertFalse(species['M_Phosphate_LPAREN_c_RPAREN_'].boundary)
         self.assertTrue(species['M_Biomass'].boundary)
 
     def test_glucose_parse_notes(self):
         reader = sbml.SBMLReader(self.doc)
-        species = reader.get_species('M_Glucose')
+        species = reader.get_species('M_Glucose_LPAREN_c_RPAREN_')
         notes_dict = sbml.parse_xhtml_species_notes(species)
         self.assertEqual(notes_dict, {
             'formula': 'C6H12O6',
@@ -300,11 +331,13 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
         self.assertTrue(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Both,
-                                   [(Compound('M_Glucose', 'C_c'), 2),
-                                    (Compound('M_Phosphate', 'C_c'), 2)],
-                                   [(Compound('M_H2O', 'C_c'), 2),
-                                    (Compound('M_Glucose_6_P', 'C_c'), 2)])
+        actual_equation = Reaction(Direction.Both, [
+            (Compound('M_Glucose_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Phosphate_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ], [
+            (Compound('M_H2O_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_g6pase_parse_notes(self):
@@ -347,10 +380,12 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
         self.assertFalse(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Forward,
-                                   [(Compound('M_Glucose_6_P', 'C_c'),
-                                     Decimal('0.56'))],
-                                   [(Compound('M_Biomass', 'C_b'), 1)])
+        actual_equation = Reaction(Direction.Forward, [
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'),
+             Decimal('0.56'))
+        ], [
+            (Compound('M_Biomass', 'C_b'), 1)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_objective_not_present(self):
@@ -363,6 +398,24 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
         reader = sbml.SBMLReader(self.doc)
         flux_bounds = list(reader.flux_bounds)
         self.assertEqual(len(flux_bounds), 0)
+
+    def test_create_and_convert_model(self):
+        reader = sbml.SBMLReader(self.doc)
+        model = reader.create_model()
+        sbml.convert_sbml_model(model)
+
+        self.assertEqual(
+            {entry.id for entry in model.compounds},
+            {'Glucose(c)', 'Glucose_6-P(c)', 'H2O(c)', 'Phosphate(c)'})
+        self.assertEqual(
+            {entry.id for entry in model.reactions},
+            {'G6Pase', 'Biomass'})
+        self.assertEqual(
+            {entry.id for entry in model.compartments},
+            {'c'})
+
+        self.assertEqual(model.limits['Biomass'], ('Biomass', 0, 1000))
+        self.assertEqual(model.biomass_reaction, 'Biomass')
 
 
 class TestSBMLDatabaseL3V1(unittest.TestCase):
@@ -379,21 +432,34 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
    <compartment id="C_b" name="boundary" constant="true"/>
   </listOfCompartments>
   <listOfSpecies>
-   <species id="M_Glucose" name="Glucose" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false"/>
-   <species id="M_Glucose_6_P" name="Glucose-6-P" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false"/>
-   <species id="M_H2O" name="H2O" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false"/>
-   <species id="M_Phosphate" name="Phosphate" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false"/>
-   <species id="M_Biomass" name="Biomass" compartment="C_b" constant="false" boundaryCondition="true" hasOnlySubstanceUnits="false"/>
+   <species id="M_Glucose_LPAREN_c_RPAREN_" name="Glucose" compartment="C_c"
+            constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false"/>
+   <species id="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_" name="Glucose-6-P"
+            compartment="C_c" constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false"/>
+   <species id="M_H2O_LPAREN_c_RPAREN_" name="H2O" compartment="C_c"
+            constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false"/>
+   <species id="M_Phosphate_LPAREN_c_RPAREN_" name="Phosphate"
+            compartment="C_c" constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false"/>
+   <species id="M_Biomass" name="Biomass" compartment="C_b" constant="false"
+            boundaryCondition="true" hasOnlySubstanceUnits="false"/>
   </listOfSpecies>
   <listOfReactions>
    <reaction id="R_G6Pase" reversible="true" fast="false">
     <listOfReactants>
-     <speciesReference species="M_Glucose" stoichiometry="2" constant="true"/>
-     <speciesReference species="M_Phosphate" stoichiometry="2" constant="true"/>
+     <speciesReference species="M_Glucose_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
+     <speciesReference species="M_Phosphate_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
     </listOfReactants>
     <listOfProducts>
-     <speciesReference species="M_H2O" stoichiometry="2" constant="true"/>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="2" constant="true"/>
+     <speciesReference species="M_H2O_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="2" constant="true"/>
     </listOfProducts>
     <notes>
      <html:p>Glucose 6-phosphatase</html:p>
@@ -401,7 +467,8 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
    </reaction>
    <reaction id="R_Biomass" reversible="false" fast="false">
     <listOfReactants>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="0.56" constant="true"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="0.56" constant="true"/>
     </listOfReactants>
     <listOfProducts>
      <speciesReference species="M_Biomass" stoichiometry="1" constant="true"/>
@@ -437,22 +504,25 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
-        self.assertEqual(species['M_Glucose'].id, 'M_Glucose')
-        self.assertEqual(species['M_Glucose'].name, 'Glucose')
-        self.assertEqual(species['M_Glucose'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose'].boundary)
+        gluc_species = species['M_Glucose_LPAREN_c_RPAREN_']
+        self.assertEqual(gluc_species.id, 'M_Glucose_LPAREN_c_RPAREN_')
+        self.assertEqual(gluc_species.name, 'Glucose')
+        self.assertEqual(gluc_species.compartment, 'C_c')
+        self.assertFalse(gluc_species.boundary)
 
-        self.assertEqual(species['M_Glucose_6_P'].id, 'M_Glucose_6_P')
-        self.assertEqual(species['M_Glucose_6_P'].name, 'Glucose-6-P')
-        self.assertEqual(species['M_Glucose_6_P'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose_6_P'].boundary)
+        g6p_species = species['M_Glucose_6_DASH_P_LPAREN_c_RPAREN_']
+        self.assertEqual(g6p_species.id, 'M_Glucose_6_DASH_P_LPAREN_c_RPAREN_')
+        self.assertEqual(g6p_species.name, 'Glucose-6-P')
+        self.assertEqual(g6p_species.compartment, 'C_c')
+        self.assertFalse(g6p_species.boundary)
 
-        self.assertEqual(species['M_H2O'].id, 'M_H2O')
-        self.assertEqual(species['M_H2O'].name, 'H2O')
-        self.assertEqual(species['M_H2O'].compartment, 'C_c')
-        self.assertFalse(species['M_H2O'].boundary)
+        h2o_species = species['M_H2O_LPAREN_c_RPAREN_']
+        self.assertEqual(h2o_species.id, 'M_H2O_LPAREN_c_RPAREN_')
+        self.assertEqual(h2o_species.name, 'H2O')
+        self.assertEqual(h2o_species.compartment, 'C_c')
+        self.assertFalse(h2o_species.boundary)
 
-        self.assertFalse(species['M_Phosphate'].boundary)
+        self.assertFalse(species['M_Phosphate_LPAREN_c_RPAREN_'].boundary)
         self.assertTrue(species['M_Biomass'].boundary)
 
     def test_g6pase_reaction_exists(self):
@@ -461,11 +531,13 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         self.assertTrue(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Both,
-                                   [(Compound('M_Glucose', 'C_c'), 2),
-                                    (Compound('M_Phosphate', 'C_c'), 2)],
-                                   [(Compound('M_H2O', 'C_c'), 2),
-                                    (Compound('M_Glucose_6_P', 'C_c'), 2)])
+        actual_equation = Reaction(Direction.Both, [
+            (Compound('M_Glucose_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Phosphate_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ], [
+            (Compound('M_H2O_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_biomass_reaction_exists(self):
@@ -474,10 +546,12 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         self.assertFalse(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Forward,
-                                   [(Compound('M_Glucose_6_P', 'C_c'),
-                                     Decimal('0.56'))],
-                                   [(Compound('M_Biomass', 'C_b'), 1)])
+        actual_equation = Reaction(Direction.Forward, [
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'),
+             Decimal('0.56'))
+        ], [
+            (Compound('M_Biomass', 'C_b'), 1)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
     def test_reaction_xml_notes(self):
@@ -501,6 +575,21 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         flux_bounds = list(reader.flux_bounds)
         self.assertEqual(len(flux_bounds), 0)
 
+    def test_create_and_convert_model(self):
+        reader = sbml.SBMLReader(self.doc)
+        model = reader.create_model()
+        sbml.convert_sbml_model(model)
+
+        self.assertEqual(
+            {entry.id for entry in model.compounds},
+            {'Glucose(c)', 'Glucose_6-P(c)', 'H2O(c)', 'Phosphate(c)'})
+        self.assertEqual(
+            {entry.id for entry in model.reactions},
+            {'G6Pase', 'Biomass'})
+        self.assertEqual(
+            {entry.id for entry in model.compartments},
+            {'c'})
+
 
 class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
     """Test parsing of a level 3 version 1 SBML file with FBC version 1"""
@@ -518,26 +607,44 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
    <compartment id="C_b" name="boundary" constant="true"/>
   </listOfCompartments>
   <listOfSpecies>
-   <species id="M_Glucose" name="Glucose" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-   <species id="M_Glucose_6_P" name="Glucose-6-P" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="-2" fbc:chemicalFormula="C6H11O9P"/>
-   <species id="M_H2O" name="H2O" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="0" fbc:chemicalFormula="H2O"/>
-   <species id="M_Phosphate" name="Phosphate" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="-2" fbc:chemicalFormula="HO4P"/>
-   <species id="M_Biomass" name="Biomass" compartment="C_b" constant="false" boundaryCondition="true" hasOnlySubstanceUnits="false"/>
+   <species id="M_Glucose_LPAREN_c_RPAREN_" name="Glucose" compartment="C_c"
+            constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="0"
+            fbc:chemicalFormula="C6H12O6"/>
+   <species id="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_" name="Glucose-6-P"
+            compartment="C_c" constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="-2"
+            fbc:chemicalFormula="C6H11O9P"/>
+   <species id="M_H2O_LPAREN_c_RPAREN_" name="H2O" compartment="C_c"
+            constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="0"
+            fbc:chemicalFormula="H2O"/>
+   <species id="M_Phosphate_LPAREN_c_RPAREN_" name="Phosphate"
+            compartment="C_c" constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="-2"
+            fbc:chemicalFormula="HO4P"/>
+   <species id="M_Biomass" name="Biomass" compartment="C_b" constant="false"
+            boundaryCondition="true" hasOnlySubstanceUnits="false"/>
   </listOfSpecies>
   <listOfReactions>
    <reaction id="R_G6Pase" reversible="true" fast="false">
     <listOfReactants>
-     <speciesReference species="M_Glucose" stoichiometry="2" constant="true"/>
-     <speciesReference species="M_Phosphate" stoichiometry="2" constant="true"/>
+     <speciesReference species="M_Glucose_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
+     <speciesReference species="M_Phosphate_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
     </listOfReactants>
     <listOfProducts>
-     <speciesReference species="M_H2O" stoichiometry="2" constant="true"/>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="2" constant="true"/>
+     <speciesReference species="M_H2O_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="2" constant="true"/>
     </listOfProducts>
    </reaction>
    <reaction id="R_Biomass" reversible="false" fast="false">
     <listOfReactants>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="0.56" constant="true"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="0.56" constant="true"/>
     </listOfReactants>
     <listOfProducts>
      <speciesReference species="M_Biomass" stoichiometry="1" constant="true"/>
@@ -552,10 +659,14 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
    </fbc:objective>
   </fbc:listOfObjectives>
   <fbc:listOfFluxBounds>
-   <fbc:fluxBound fbc:reaction="R_G6Pase" fbc:operation="greaterEqual" fbc:value="-10"/>
-   <fbc:fluxBound fbc:reaction="R_G6Pase" fbc:operation="lessEqual" fbc:value="1000"/>
-   <fbc:fluxBound fbc:reaction="R_Biomass" fbc:operation="greaterEqual" fbc:value="0"/>
-   <fbc:fluxBound fbc:reaction="R_Biomass" fbc:operation="lessEqual" fbc:value="1000"/>
+   <fbc:fluxBound fbc:reaction="R_G6Pase" fbc:operation="greaterEqual"
+                  fbc:value="-10"/>
+   <fbc:fluxBound fbc:reaction="R_G6Pase" fbc:operation="lessEqual"
+                  fbc:value="1000"/>
+   <fbc:fluxBound fbc:reaction="R_Biomass" fbc:operation="greaterEqual"
+                  fbc:value="0"/>
+   <fbc:fluxBound fbc:reaction="R_Biomass" fbc:operation="lessEqual"
+                  fbc:value="1000"/>
   </fbc:listOfFluxBounds>
  </model>
 </sbml>'''.encode('utf-8'))
@@ -579,28 +690,31 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
-        self.assertEqual(species['M_Glucose'].id, 'M_Glucose')
-        self.assertEqual(species['M_Glucose'].name, 'Glucose')
-        self.assertEqual(species['M_Glucose'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose'].boundary)
-        self.assertEqual(species['M_Glucose'].formula, 'C6H12O6')
-        self.assertEqual(species['M_Glucose'].charge, 0)
+        gluc_species = species['M_Glucose_LPAREN_c_RPAREN_']
+        self.assertEqual(gluc_species.id, 'M_Glucose_LPAREN_c_RPAREN_')
+        self.assertEqual(gluc_species.name, 'Glucose')
+        self.assertEqual(gluc_species.compartment, 'C_c')
+        self.assertFalse(gluc_species.boundary)
+        self.assertEqual(gluc_species.formula, 'C6H12O6')
+        self.assertEqual(gluc_species.charge, 0)
 
-        self.assertEqual(species['M_Glucose_6_P'].id, 'M_Glucose_6_P')
-        self.assertEqual(species['M_Glucose_6_P'].name, 'Glucose-6-P')
-        self.assertEqual(species['M_Glucose_6_P'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose_6_P'].boundary)
-        self.assertEqual(species['M_Glucose_6_P'].formula, 'C6H11O9P')
-        self.assertEqual(species['M_Glucose_6_P'].charge, -2)
+        g6p_species = species['M_Glucose_6_DASH_P_LPAREN_c_RPAREN_']
+        self.assertEqual(g6p_species.id, 'M_Glucose_6_DASH_P_LPAREN_c_RPAREN_')
+        self.assertEqual(g6p_species.name, 'Glucose-6-P')
+        self.assertEqual(g6p_species.compartment, 'C_c')
+        self.assertFalse(g6p_species.boundary)
+        self.assertEqual(g6p_species.formula, 'C6H11O9P')
+        self.assertEqual(g6p_species.charge, -2)
 
-        self.assertEqual(species['M_H2O'].id, 'M_H2O')
-        self.assertEqual(species['M_H2O'].name, 'H2O')
-        self.assertEqual(species['M_H2O'].compartment, 'C_c')
-        self.assertFalse(species['M_H2O'].boundary)
-        self.assertEqual(species['M_H2O'].formula, 'H2O')
-        self.assertEqual(species['M_H2O'].charge, 0)
+        h2o_species = species['M_H2O_LPAREN_c_RPAREN_']
+        self.assertEqual(h2o_species.id, 'M_H2O_LPAREN_c_RPAREN_')
+        self.assertEqual(h2o_species.name, 'H2O')
+        self.assertEqual(h2o_species.compartment, 'C_c')
+        self.assertFalse(h2o_species.boundary)
+        self.assertEqual(h2o_species.formula, 'H2O')
+        self.assertEqual(h2o_species.charge, 0)
 
-        self.assertFalse(species['M_Phosphate'].boundary)
+        self.assertFalse(species['M_Phosphate_LPAREN_c_RPAREN_'].boundary)
         self.assertTrue(species['M_Biomass'].boundary)
 
         self.assertIsNone(species['M_Biomass'].formula)
@@ -612,11 +726,13 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
         self.assertTrue(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Both,
-                                   [(Compound('M_Glucose', 'C_c'), 2),
-                                    (Compound('M_Phosphate', 'C_c'), 2)],
-                                   [(Compound('M_H2O', 'C_c'), 2),
-                                    (Compound('M_Glucose_6_P', 'C_c'), 2)])
+        actual_equation = Reaction(Direction.Both, [
+            (Compound('M_Glucose_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Phosphate_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ], [
+            (Compound('M_H2O_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
         self.assertEqual(reaction.properties['lower_flux'], -10)
@@ -628,10 +744,12 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
         self.assertFalse(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Forward,
-                                   [(Compound('M_Glucose_6_P', 'C_c'),
-                                     Decimal('0.56'))],
-                                   [(Compound('M_Biomass', 'C_b'), 1)])
+        actual_equation = Reaction(Direction.Forward, [
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'),
+             Decimal('0.56'))
+        ], [
+            (Compound('M_Biomass', 'C_b'), 1)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
         self.assertEqual(reaction.properties['lower_flux'], 0)
@@ -671,6 +789,25 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
             ('greaterEqual', -10),
             ('lessEqual', 1000)})
 
+    def test_create_and_convert_model(self):
+        reader = sbml.SBMLReader(self.doc)
+        model = reader.create_model()
+        sbml.convert_sbml_model(model)
+
+        self.assertEqual(
+            {entry.id for entry in model.compounds},
+            {'Glucose(c)', 'Glucose_6-P(c)', 'H2O(c)', 'Phosphate(c)'})
+        self.assertEqual(
+            {entry.id for entry in model.reactions},
+            {'G6Pase', 'Biomass'})
+        self.assertEqual(
+            {entry.id for entry in model.compartments},
+            {'c'})
+
+        self.assertEqual(model.limits['Biomass'], ('Biomass', 0, 1000))
+        self.assertEqual(model.limits['G6Pase'], ('G6Pase', -10, 1000))
+        self.assertEqual(model.biomass_reaction, 'Biomass')
+
 
 class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
     """Test parsing of a level 3 version 1 SBML file with FBC version 2"""
@@ -693,17 +830,31 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
    <compartment id="C_b" name="boundary" constant="true"/>
   </listOfCompartments>
   <listOfSpecies>
-   <species id="M_Glucose" metaid="meta_M_Glucose" name="Glucose" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="0" fbc:chemicalFormula="C6H12O6">
+   <species id="M_Glucose_LPAREN_c_RPAREN_"
+            metaid="meta_M_Glucose_LPAREN_c_RPAREN_" name="Glucose"
+            compartment="C_c" constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="0"
+            fbc:chemicalFormula="C6H12O6">
     <notes>
      <body xmlns="http://www.w3.org/1999/xhtml">
       <p>This is compound information intended to be seen by humans.</p>
      </body>
     </notes>
    </species>
-   <species id="M_Glucose_6_P" name="Glucose-6-P" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="-2" fbc:chemicalFormula="C6H11O9P"/>
-   <species id="M_H2O" name="H2O" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="0" fbc:chemicalFormula="H2O"/>
-   <species id="M_Phosphate" name="Phosphate" compartment="C_c" constant="false" boundaryCondition="false" hasOnlySubstanceUnits="false" fbc:charge="-2" fbc:chemicalFormula="HO4P"/>
-   <species id="M_Biomass" name="Biomass" compartment="C_b" constant="false" boundaryCondition="true" hasOnlySubstanceUnits="false"/>
+   <species id="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_" name="Glucose-6-P"
+            compartment="C_c" constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="-2"
+            fbc:chemicalFormula="C6H11O9P"/>
+   <species id="M_H2O_LPAREN_c_RPAREN_" name="H2O" compartment="C_c"
+            constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="0"
+            fbc:chemicalFormula="H2O"/>
+   <species id="M_Phosphate_LPAREN_c_RPAREN_" name="Phosphate"
+            compartment="C_c" constant="false" boundaryCondition="false"
+            hasOnlySubstanceUnits="false" fbc:charge="-2"
+            fbc:chemicalFormula="HO4P"/>
+   <species id="M_Biomass" name="Biomass" compartment="C_b" constant="false"
+            boundaryCondition="true" hasOnlySubstanceUnits="false"/>
   </listOfSpecies>
   <listOfParameters>
    <parameter constant="true" id="P_lower_G6Pase" value="-10"/>
@@ -711,14 +862,20 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
    <parameter constant="true" id="P_upper_default" value="1000"/>
   </listOfParameters>
   <listOfReactions>
-   <reaction id="R_G6Pase" metaid="meta_R_G6Pase" reversible="true" fast="false" fbc:lowerFluxBound="P_lower_G6Pase" fbc:upperFluxBound="P_upper_default">
+   <reaction id="R_G6Pase" metaid="meta_R_G6Pase" reversible="true"
+             fast="false" fbc:lowerFluxBound="P_lower_G6Pase"
+             fbc:upperFluxBound="P_upper_default">
     <listOfReactants>
-     <speciesReference species="M_Glucose" stoichiometry="2" constant="true"/>
-     <speciesReference species="M_Phosphate" stoichiometry="2" constant="true"/>
+     <speciesReference species="M_Glucose_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
+     <speciesReference species="M_Phosphate_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
     </listOfReactants>
     <listOfProducts>
-     <speciesReference species="M_H2O" stoichiometry="2" constant="true"/>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="2" constant="true"/>
+     <speciesReference species="M_H2O_LPAREN_c_RPAREN_" stoichiometry="2"
+                       constant="true"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="2" constant="true"/>
     </listOfProducts>
     <notes>
      <body xmlns="http://www.w3.org/1999/xhtml">
@@ -738,9 +895,12 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
      </RDF>
     </annotation>
    </reaction>
-   <reaction id="R_Biomass" reversible="false" fast="false" fbc:lowerFluxBound="P_lower_zero" fbc:upperFluxBound="P_upper_default">
+   <reaction id="R_Biomass" reversible="false" fast="false"
+             fbc:lowerFluxBound="P_lower_zero"
+             fbc:upperFluxBound="P_upper_default">
     <listOfReactants>
-     <speciesReference species="M_Glucose_6_P" stoichiometry="0.56" constant="true"/>
+     <speciesReference species="M_Glucose_6_DASH_P_LPAREN_c_RPAREN_"
+                       stoichiometry="0.56" constant="true"/>
     </listOfReactants>
     <listOfProducts>
      <speciesReference species="M_Biomass" stoichiometry="1" constant="true"/>
@@ -776,30 +936,33 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
         species = {entry.id: entry for entry in reader.species}
         self.assertEqual(len(species), 5)
 
-        self.assertEqual(species['M_Glucose'].id, 'M_Glucose')
-        self.assertEqual(species['M_Glucose'].name, 'Glucose')
-        self.assertEqual(species['M_Glucose'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose'].boundary)
-        self.assertEqual(species['M_Glucose'].formula, 'C6H12O6')
-        self.assertEqual(species['M_Glucose'].charge, 0)
-        self.assertIsNotNone(species['M_Glucose'].xml_notes)
+        gluc_species = species['M_Glucose_LPAREN_c_RPAREN_']
+        self.assertEqual(gluc_species.id, 'M_Glucose_LPAREN_c_RPAREN_')
+        self.assertEqual(gluc_species.name, 'Glucose')
+        self.assertEqual(gluc_species.compartment, 'C_c')
+        self.assertFalse(gluc_species.boundary)
+        self.assertEqual(gluc_species.formula, 'C6H12O6')
+        self.assertEqual(gluc_species.charge, 0)
+        self.assertIsNotNone(gluc_species.xml_notes)
 
-        self.assertEqual(species['M_Glucose_6_P'].id, 'M_Glucose_6_P')
-        self.assertEqual(species['M_Glucose_6_P'].name, 'Glucose-6-P')
-        self.assertEqual(species['M_Glucose_6_P'].compartment, 'C_c')
-        self.assertFalse(species['M_Glucose_6_P'].boundary)
-        self.assertEqual(species['M_Glucose_6_P'].formula, 'C6H11O9P')
-        self.assertEqual(species['M_Glucose_6_P'].charge, -2)
-        self.assertIsNone(species['M_Glucose_6_P'].xml_notes)
+        g6p_species = species['M_Glucose_6_DASH_P_LPAREN_c_RPAREN_']
+        self.assertEqual(g6p_species.id, 'M_Glucose_6_DASH_P_LPAREN_c_RPAREN_')
+        self.assertEqual(g6p_species.name, 'Glucose-6-P')
+        self.assertEqual(g6p_species.compartment, 'C_c')
+        self.assertFalse(g6p_species.boundary)
+        self.assertEqual(g6p_species.formula, 'C6H11O9P')
+        self.assertEqual(g6p_species.charge, -2)
+        self.assertIsNone(g6p_species.xml_notes)
 
-        self.assertEqual(species['M_H2O'].id, 'M_H2O')
-        self.assertEqual(species['M_H2O'].name, 'H2O')
-        self.assertEqual(species['M_H2O'].compartment, 'C_c')
-        self.assertFalse(species['M_H2O'].boundary)
-        self.assertEqual(species['M_H2O'].formula, 'H2O')
-        self.assertEqual(species['M_H2O'].charge, 0)
+        h2o_species = species['M_H2O_LPAREN_c_RPAREN_']
+        self.assertEqual(h2o_species.id, 'M_H2O_LPAREN_c_RPAREN_')
+        self.assertEqual(h2o_species.name, 'H2O')
+        self.assertEqual(h2o_species.compartment, 'C_c')
+        self.assertFalse(h2o_species.boundary)
+        self.assertEqual(h2o_species.formula, 'H2O')
+        self.assertEqual(h2o_species.charge, 0)
 
-        self.assertFalse(species['M_Phosphate'].boundary)
+        self.assertFalse(species['M_Phosphate_LPAREN_c_RPAREN_'].boundary)
         self.assertTrue(species['M_Biomass'].boundary)
 
         self.assertIsNone(species['M_Biomass'].formula)
@@ -811,11 +974,13 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
         self.assertTrue(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Both,
-                                   [(Compound('M_Glucose', 'C_c'), 2),
-                                    (Compound('M_Phosphate', 'C_c'), 2)],
-                                   [(Compound('M_H2O', 'C_c'), 2),
-                                    (Compound('M_Glucose_6_P', 'C_c'), 2)])
+        actual_equation = Reaction(Direction.Both, [
+            (Compound('M_Glucose_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Phosphate_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ], [
+            (Compound('M_H2O_LPAREN_c_RPAREN_', 'C_c'), 2),
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'), 2)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
         self.assertEqual(reaction.properties['lower_flux'], -10)
@@ -830,10 +995,12 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
         self.assertFalse(reaction.reversible)
 
         # Compare equation of reaction
-        actual_equation = Reaction(Direction.Forward,
-                                   [(Compound('M_Glucose_6_P', 'C_c'),
-                                     Decimal('0.56'))],
-                                   [(Compound('M_Biomass', 'C_b'), 1)])
+        actual_equation = Reaction(Direction.Forward, [
+            (Compound('M_Glucose_6_DASH_P_LPAREN_c_RPAREN_', 'C_c'),
+             Decimal('0.56'))
+        ], [
+            (Compound('M_Biomass', 'C_b'), 1)
+        ])
         self.assertEqual(reaction.equation, actual_equation)
 
         self.assertEqual(reaction.properties['lower_flux'], 0)
@@ -862,3 +1029,22 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
         reader = sbml.SBMLReader(self.doc)
         flux_bounds = list(reader.flux_bounds)
         self.assertEqual(len(flux_bounds), 0)
+
+    def test_create_and_convert_model(self):
+        reader = sbml.SBMLReader(self.doc)
+        model = reader.create_model()
+        sbml.convert_sbml_model(model)
+
+        self.assertEqual(
+            {entry.id for entry in model.compounds},
+            {'Glucose(c)', 'Glucose_6-P(c)', 'H2O(c)', 'Phosphate(c)'})
+        self.assertEqual(
+            {entry.id for entry in model.reactions},
+            {'G6Pase', 'Biomass'})
+        self.assertEqual(
+            {entry.id for entry in model.compartments},
+            {'c'})
+
+        self.assertEqual(model.limits['Biomass'], ('Biomass', 0, 1000))
+        self.assertEqual(model.limits['G6Pase'], ('G6Pase', -10, 1000))
+        self.assertEqual(model.biomass_reaction, 'Biomass')

--- a/psamm/tests/test_datasource_sbml.py
+++ b/psamm/tests/test_datasource_sbml.py
@@ -186,6 +186,8 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
             {entry.id for entry in model.compartments},
             {'cell'})
 
+        self.assertEqual(set(model.model), {'Biomass', 'G6Pase'})
+
 
 class TestSBMLDatabaseL2V5(unittest.TestCase):
     """Test parsing of a simple level 2 version 5 SBML file"""
@@ -416,6 +418,7 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
 
         self.assertEqual(model.limits['Biomass'], ('Biomass', 0, 1000))
         self.assertEqual(model.biomass_reaction, 'Biomass')
+        self.assertEqual(set(model.model), {'Biomass', 'G6Pase'})
 
 
 class TestSBMLDatabaseL3V1(unittest.TestCase):
@@ -589,6 +592,8 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
         self.assertEqual(
             {entry.id for entry in model.compartments},
             {'c'})
+
+        self.assertEqual(set(model.model), {'Biomass', 'G6Pase'})
 
 
 class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
@@ -806,6 +811,7 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
 
         self.assertEqual(model.limits['Biomass'], ('Biomass', 0, 1000))
         self.assertEqual(model.limits['G6Pase'], ('G6Pase', -10, 1000))
+        self.assertEqual(set(model.model), {'Biomass', 'G6Pase'})
         self.assertEqual(model.biomass_reaction, 'Biomass')
 
 
@@ -1047,4 +1053,5 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
 
         self.assertEqual(model.limits['Biomass'], ('Biomass', 0, 1000))
         self.assertEqual(model.limits['G6Pase'], ('G6Pase', -10, 1000))
+        self.assertEqual(set(model.model), {'Biomass', 'G6Pase'})
         self.assertEqual(model.biomass_reaction, 'Biomass')


### PR DESCRIPTION
`psamm-import` currently performs many additional model conversions on top of the output of `SBMLReader` to make additional model data available and to fit the model into the native representation. This is an attempt to move this functionality into the `sbml` module so it can be used from the PSAMM API.