### PR TITLE
Travis: Use Ubuntu Trusty as distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 cache:
@@ -9,7 +10,9 @@ addons:
         packages:
             - libgmp-dev
             - libgmp10
-            - glpk
+            - libglpk36
+            - libglpk-dev
+            - glpk-utils
             - swig
 
 install:


### PR DESCRIPTION
- [ ] Requires GLPK support from Travis: https://github.com/travis-ci/apt-package-whitelist/pull/4133