### PR TITLE
sbml: Use cElementTree if possible

### DIFF
--- a/psamm/tests/test_command.py
+++ b/psamm/tests/test_command.py
@@ -20,7 +20,6 @@ from __future__ import unicode_literals
 import sys
 import os
 import argparse
-import codecs
 import shutil
 import tempfile
 from contextlib import contextmanager
@@ -103,6 +102,7 @@ class MockSolverCommand(SolverCommandMixin, Command):
     """
     def run(self):
         solver = self._get_solver()
+        print(solver)
 
 
 class BaseCommandTest(object):
@@ -579,7 +579,7 @@ class TestCommandMain(unittest.TestCase, BaseCommandTest):
 
 class TestSBMLCommandMain(unittest.TestCase, BaseCommandTest):
     def setUp(self):
-        doc = StringIO('''<?xml version="1.0" encoding="UTF-8"?>
+        doc = BytesIO('''<?xml version="1.0" encoding="UTF-8"?>
 <sbml xmlns="http://www.sbml.org/sbml/level3/version1/core"
       xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1"
       xmlns:html="http://www.w3.org/1999/xhtml"
@@ -631,7 +631,7 @@ class TestSBMLCommandMain(unittest.TestCase, BaseCommandTest):
    <fbc:fluxBound fbc:reaction="R_Biomass" fbc:operation="lessEqual" fbc:value="1000"/>
   </fbc:listOfFluxBounds>
  </model>
-</sbml>''')
+</sbml>'''.encode('utf-8'))
 
         reader = sbml.SBMLReader(doc)
         self._model = reader.create_model()

--- a/psamm/tests/test_datasource_sbml.py
+++ b/psamm/tests/test_datasource_sbml.py
@@ -16,6 +16,8 @@
 #
 # Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
+from __future__ import unicode_literals
+
 import unittest
 
 from psamm.datasource import sbml
@@ -23,14 +25,14 @@ from psamm.reaction import Reaction, Compound, Direction
 
 from decimal import Decimal
 from fractions import Fraction
-from six import StringIO
+from six import BytesIO
 
 
 class TestSBMLDatabaseL1V2(unittest.TestCase):
     """Test parsing of a simple level 1 version 2 SBML file"""
 
     def setUp(self):
-        self.doc = StringIO('''<?xml version="1.0" encoding="UTF-8"?>
+        self.doc = BytesIO('''<?xml version="1.0" encoding="UTF-8"?>
 <sbml xmlns="http://www.sbml.org/sbml/level1"
       xmlns:html="http://www.w3.org/1999/xhtml"
       level="1" version="2">
@@ -70,7 +72,7 @@ class TestSBMLDatabaseL1V2(unittest.TestCase):
    </reaction>
   </listOfReactions>
  </model>
-</sbml>''')
+</sbml>'''.encode('utf-8'))
 
     def test_model_name(self):
         reader = sbml.SBMLReader(self.doc)
@@ -169,7 +171,7 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
     """Test parsing of a simple level 2 version 5 SBML file"""
 
     def setUp(self):
-        self.doc = StringIO('''<?xml version="1.0" encoding="UTF-8"?>
+        self.doc = BytesIO('''<?xml version="1.0" encoding="UTF-8"?>
 <sbml xmlns="http://www.sbml.org/sbml/level2/version5"
       xmlns:html="http://www.w3.org/1999/xhtml"
       level="2" version="5">
@@ -209,7 +211,7 @@ class TestSBMLDatabaseL2V5(unittest.TestCase):
    </reaction>
   </listOfReactions>
  </model>
-</sbml>''')
+</sbml>'''.encode('utf-8'))
 
     def test_model_name(self):
         reader = sbml.SBMLReader(self.doc)
@@ -309,7 +311,7 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
     """Test parsing of a simple level 3 version 1 SBML file"""
 
     def setUp(self):
-        self.doc = StringIO('''<?xml version="1.0" encoding="UTF-8"?>
+        self.doc = BytesIO('''<?xml version="1.0" encoding="UTF-8"?>
 <sbml xmlns="http://www.sbml.org/sbml/level3/version1/core"
       xmlns:html="http://www.w3.org/1999/xhtml"
       level="3" version="1">
@@ -349,7 +351,7 @@ class TestSBMLDatabaseL3V1(unittest.TestCase):
    </reaction>
   </listOfReactions>
  </model>
-</sbml>''')
+</sbml>'''.encode('utf-8'))
 
     def test_model_name(self):
         reader = sbml.SBMLReader(self.doc)
@@ -446,7 +448,7 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
     """Test parsing of a level 3 version 1 SBML file with FBC version 1"""
 
     def setUp(self):
-        self.doc = StringIO('''<?xml version="1.0" encoding="UTF-8"?>
+        self.doc = BytesIO('''<?xml version="1.0" encoding="UTF-8"?>
 <sbml xmlns="http://www.sbml.org/sbml/level3/version1/core"
       xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version1"
       xmlns:html="http://www.w3.org/1999/xhtml"
@@ -498,7 +500,7 @@ class TestSBMLDatabaseL3V1WithFBCV1(unittest.TestCase):
    <fbc:fluxBound fbc:reaction="R_Biomass" fbc:operation="lessEqual" fbc:value="1000"/>
   </fbc:listOfFluxBounds>
  </model>
-</sbml>''')
+</sbml>'''.encode('utf-8'))
 
     def test_model_name(self):
         reader = sbml.SBMLReader(self.doc)
@@ -616,7 +618,7 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
     """Test parsing of a level 3 version 1 SBML file with FBC version 2"""
 
     def setUp(self):
-        self.doc = StringIO('''<?xml version="1.0" encoding="UTF-8"?>
+        self.doc = BytesIO('''<?xml version="1.0" encoding="UTF-8"?>
 <sbml xmlns="http://www.sbml.org/sbml/level3/version1/core"
       xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version2"
       xmlns:html="http://www.w3.org/1999/xhtml"
@@ -667,7 +669,7 @@ class TestSBMLDatabaseL3V1WithFBCV2(unittest.TestCase):
    </fbc:objective>
   </fbc:listOfObjectives>
  </model>
-</sbml>''')
+</sbml>'''.encode('utf-8'))
 
     def test_model_name(self):
         reader = sbml.SBMLReader(self.doc)


### PR DESCRIPTION
It was also considered whether lxml could be used. lxml would have
been able to supply additional information, such as line numbers of
element definitions. However, lxml has compatibility issues with
the way namespaces are handled in the sbml module currently.

The tests that rely on inline XML data were modified. On Python 2.7,
cElementTree only works with a file that reads
bytes. StringIO returns unicode if initialized with a unicode
string. This results in cElementTree failing if a unicode
string is supplied in test cases (or if unicode_literals is set).
Instead use BytesIO with a string explicitly encoded as UTF-8.
This works in all cases.