### PR TITLE
Improvements to Formula

### DIFF
--- a/psamm/balancecheck.py
+++ b/psamm/balancecheck.py
@@ -23,7 +23,7 @@ import logging
 
 from six.moves import reduce
 
-from .formula import Formula
+from .formula import Formula, ParseError
 
 logger = logging.getLogger(__name__)
 
@@ -106,10 +106,12 @@ def formula_balance(model):
             try:
                 f = Formula.parse(compound.formula).flattened()
                 compound_formula[compound.id] = f
-            except ValueError:
-                logger.warning(
-                    'Error parsing formula for compound {}: {}'.format(
-                        compound.id, compound.formula), exc_info=True)
+            except ParseError as e:
+                msg = 'Error parsing formula for compound {}:\n{}\n{}'.format(
+                    compound.id, e, compound.formula)
+                if e.indicator is not None:
+                    msg += '\n{}'.format(e.indicator)
+                logger.warning(msg)
 
     for reaction in model.reactions:
         yield reaction, reaction_formula(reaction.equation, compound_formula)

--- a/psamm/tests/test_formula.py
+++ b/psamm/tests/test_formula.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 import unittest
 
@@ -117,6 +117,26 @@ class TestFormula(unittest.TestCase):
         f = Formula({Atom.H: 2, Atom.O: 1}).repeat(4)
         self.assertEqual(f, Formula({Formula({Atom.H: 2, Atom.O: 1}): 4}))
 
+    def test_formula_intersection(self):
+        f1 = Formula({Atom.H: 4, Atom.N: 1})
+        f2 = Formula({Atom.H: 2, Atom.O: 1})
+        f = f1 & f2
+        self.assertEqual(f, Formula({Atom.H: 2}))
+
+    def test_formula_intersection_with_atom(self):
+        f = Formula({Atom.H: 4, Atom.N: 1}) & Atom.H
+        self.assertEqual(f, Formula({Atom.H: 1}))
+
+    def test_formula_subtraction(self):
+        f1 = Formula({Atom.H: 4, Atom.N: 1})
+        f2 = Formula({Atom.H: 2, Atom.O: 1})
+        f = f1 - f2
+        self.assertEqual(f, Formula({Atom.H: 2, Atom.N: 1}))
+
+    def test_formula_subtraction_with_atom(self):
+        f = Formula({Atom.H: 4, Atom.N: 1}) - Atom.H
+        self.assertEqual(f, Formula({Atom.H: 3, Atom.N: 1}))
+
     def test_formula_equals_other_formula(self):
         f = Formula({Atom.H: 2, Atom.O: 1})
         self.assertEqual(f, Formula({Atom.O: 1, Atom.H: 2}))
@@ -128,6 +148,10 @@ class TestFormula(unittest.TestCase):
     def test_formula_not_equals_other_with_different_number(self):
         f = Formula({Atom.Au: 1})
         self.assertNotEqual(f, Formula({Atom.Au: 2}))
+
+    def test_formula_iter(self):
+        f = Formula({Atom.H: 12, Atom.C: 6, Atom.O: 6})
+        self.assertEqual(set(iter(f)), {Atom.H, Atom.C, Atom.O})
 
     def test_formula_items(self):
         f = Formula({Atom.H: 12, Atom.C: 6, Atom.O: 6})

--- a/psamm/tests/test_formula.py
+++ b/psamm/tests/test_formula.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from psamm.formula import Formula, FormulaElement, Atom, Radical
+from psamm.formula import Formula, FormulaElement, Atom, Radical, ParseError
 
 
 class TestFormulaElement(unittest.TestCase):
@@ -316,6 +316,20 @@ class TestFormulaParser(unittest.TestCase):
         f = Formula.parse('C2H4NO2(R1)')
         self.assertEqual(f, Formula({
             Atom.C: 2, Atom.H: 4, Atom.N: 1, Atom.O: 2, Radical('R1'): 1}))
+
+    def test_formula_parse_error(self):
+        with self.assertRaises(ParseError):
+            Formula.parse('H2O. ABC')
+
+
+class TestFormulaParseError(unittest.TestCase):
+    def test_create_with_span(self):
+        e = ParseError('This is an error', span=(4, 7))
+        self.assertEqual(e.indicator, '    ^^^')
+
+    def test_create_without_span(self):
+        e = ParseError('This is an error')
+        self.assertIsNone(e.indicator)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Base `Formula` on `Counter` instead of `dict`. This allows some multiset operators to be defined more efficiently. The operators `__and__` and `__sub__` are added.
- Add a `ParseError` exception in the `formula` module and use it to report errors in `Formula.parse()`. The parse exception may contain a span indicating the location of the parse error in the input string. This information is used in `balancecheck` to show better error messages.