### PR TITLE
Forward solver errors and raise error on non-optimal solutions

### DIFF
--- a/psamm/fluxanalysis.py
+++ b/psamm/fluxanalysis.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Implementation of Flux Balance Analysis."""
 
@@ -24,7 +24,7 @@ import random
 
 from .lpsolver import lp
 
-from six import iteritems
+from six import iteritems, raise_from
 
 # Module-level logging
 logger = logging.getLogger(__name__)
@@ -266,10 +266,10 @@ class FluxBalanceProblem(object):
             self._remove_constr.pop().delete()
 
         try:
-            result = self._prob.solve(lp.ObjectiveSense.Maximize)
-            if not result:
-                raise FluxBalanceError('Non-optimal solution: {}'.format(
-                    result.status), result=result)
+            self._prob.solve(lp.ObjectiveSense.Maximize)
+        except lp.SolverError as e:
+            raise_from(FluxBalanceError('Failed to solve: {}'.format(
+                e), result=self._prob.result), e)
         finally:
             # Set temporary constraints to be removed on next solve call
             self._remove_constr = self._temp_constr

--- a/psamm/fluxcoupling.py
+++ b/psamm/fluxcoupling.py
@@ -111,8 +111,9 @@ class FluxCouplingProblem(object):
 
         results = []
         for sense in (lp.ObjectiveSense.Minimize, lp.ObjectiveSense.Maximize):
-            result = self._prob.solve(sense)
-            if not result:
+            try:
+                result = self._prob.solve(sense)
+            except lp.SolverError:
                 results.append(None)
             else:
                 results.append(result.get_value(self._vbow(reaction_1)))

--- a/psamm/lpsolver/cplex.py
+++ b/psamm/lpsolver/cplex.py
@@ -352,8 +352,13 @@ class Problem(BaseProblem):
                 self._cp.solution.status.abort_user):
             raise KeyboardInterrupt()
 
-    def solve(self, sense=None):
-        """Solve problem"""
+    def solve_unchecked(self, sense=None):
+        """Solve problem and return result.
+
+        The user must manually check the status of the result to determine
+        whether an optimal solution was found. A :class:`SolverError` may still
+        be raised if the underlying solver raises an exception.
+        """
         if sense is not None:
             self.set_objective_sense(sense)
 

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -272,8 +272,13 @@ class Problem(BaseProblem):
 
         swiglpk.glp_set_obj_dir(self._p, self.OBJ_SENSE_MAP[sense])
 
-    def solve(self, sense=None):
-        """Solve problem."""
+    def solve_unchecked(self, sense=None):
+        """Solve problem and return result.
+
+        The user must manually check the status of the result to determine
+        whether an optimal solution was found. A :class:`SolverError` may still
+        be raised if the underlying solver raises an exception.
+        """
         if sense is not None:
             self.set_objective_sense(sense)
 

--- a/psamm/lpsolver/glpk.py
+++ b/psamm/lpsolver/glpk.py
@@ -32,7 +32,7 @@ from .lp import Constraint as BaseConstraint
 from .lp import Problem as BaseProblem
 from .lp import Result as BaseResult
 from .lp import (Expression, RelationSense, ObjectiveSense, VariableType,
-                 InvalidResultError, ranged_property)
+                 InvalidResultError, ranged_property, SolverError)
 
 # Module-level logging
 logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ swiglpk.glp_term_hook(_term_hook)
 _INF = float('inf')
 
 
-class GLPKError(Exception):
+class GLPKError(SolverError):
     """Error from calling GLPK library."""
 
 

--- a/psamm/lpsolver/gurobi.py
+++ b/psamm/lpsolver/gurobi.py
@@ -240,8 +240,13 @@ class Problem(BaseProblem):
 
         self._p.ModelSense = self.OBJ_SENSE_MAP[sense]
 
-    def solve(self, sense=None):
-        """Solve problem."""
+    def solve_unchecked(self, sense=None):
+        """Solve problem and return result.
+
+        The user must manually check the status of the result to determine
+        whether an optimal solution was found. A :class:`SolverError` may still
+        be raised if the underlying solver raises an exception.
+        """
         if sense is not None:
             self.set_objective_sense(sense)
         self._p.optimize()

--- a/psamm/lpsolver/lp.py
+++ b/psamm/lpsolver/lp.py
@@ -771,9 +771,25 @@ class Problem(object):
     def set_objective_sense(self, sense):
         """Set type of problem (minimize or maximize)"""
 
-    @abc.abstractmethod
     def solve(self, sense=None):
-        """Solve problem and return result"""
+        """Solve problem and return result.
+
+        Raises :class:`SolverError` if the solution is not optimal.
+        """
+        result = self.solve_unchecked(sense)
+        if not result:
+            raise SolverError('Solution not optimal: {}'.format(result.status))
+
+        return result
+
+    @abc.abstractmethod
+    def solve_unchecked(self, sense=None):
+        """Solve problem and return result.
+
+        The user must manually check the status of the result to determine
+        whether an optimal solution was found. A :class:`SolverError` may still
+        be raised if the underlying solver raises an exception.
+        """
 
     @abc.abstractproperty
     def result(self):

--- a/psamm/lpsolver/lp.py
+++ b/psamm/lpsolver/lp.py
@@ -47,6 +47,10 @@ from six.moves import range, reduce
 _INF = float('inf')
 
 
+class SolverError(Exception):
+    """Error wrapping solver specific errors."""
+
+
 class VariableSet(tuple):
     """A tuple used to represent sets of variables."""
 

--- a/psamm/lpsolver/qsoptex.py
+++ b/psamm/lpsolver/qsoptex.py
@@ -175,8 +175,13 @@ class Problem(BaseProblem):
         else:
             raise ValueError('Invalid objective sense')
 
-    def solve(self, sense=None):
-        """Solve problem"""
+    def solve_unchecked(self, sense=None):
+        """Solve problem and return result.
+
+        The user must manually check the status of the result to determine
+        whether an optimal solution was found. A :class:`SolverError` may still
+        be raised if the underlying solver raises an exception.
+        """
         if sense is not None:
             self.set_objective_sense(sense)
         self._p.solve()

--- a/psamm/tests/test_lpsolver_cplex.py
+++ b/psamm/tests/test_lpsolver_cplex.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2014-2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2014-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 import unittest
 
@@ -98,8 +98,12 @@ class TestCplexProblem(unittest.TestCase):
                                     prob.var('z') <= 3)
         prob.set_objective_sense(lp.ObjectiveSense.Maximize)
         prob.set_linear_objective(2*prob.var('x'))
-        result = prob.solve()
+        result = prob.solve_unchecked()
         self.assertFalse(result)
+
+        # Check that the normal solve raises SolverError when non-optimal.
+        with self.assertRaises(lp.SolverError):
+            prob.solve()
 
     def test_constraint_delete(self):
         prob = self.solver.create_problem()


### PR DESCRIPTION
Adds the SolverError in the lp module. Exceptions raised from the
solver when solve() is called should inherit from this or should
be wrapped as this to allow callers to handle such conditions
gracefully.

In addition, the SolverError is also raised by solve() when a non-optimal solution is found.
This helps avoid a common bug where the result is not checked and
therefore non-optimal solution values are used as though an optimal
solution was found. Instead the solve() now raises a SolverError
when no optimal solution is found. This makes it impossible to
forget to check the solution in the most common case. In cases
when the exception is not desired the new solve_unchecked() can
be used which has the old behavior.