### PR TITLE
Primarpairs ambiguous reaction printing

### DIFF
--- a/psamm/commands/primarypairs.py
+++ b/psamm/commands/primarypairs.py
@@ -178,8 +178,9 @@ class PrimaryPairsCommand(SolverCommandMixin, Command):
     def _run_find_primary_pairs(
             self, compound_formula, reactions, element_weight):
         reaction_pairs = [(r.id, r.equation) for r in reactions]
+        ambig = self._args.ambiguous
         prediction, _ = findprimarypairs.predict_compound_pairs_iterated(
-            reaction_pairs, compound_formula, element_weight=element_weight)
+            reaction_pairs, compound_formula, ambig, element_weight=element_weight)
 
         for reaction_id, _ in reaction_pairs:
             if reaction_id not in prediction:

--- a/psamm/commands/primarypairs.py
+++ b/psamm/commands/primarypairs.py
@@ -207,7 +207,6 @@ class PrimaryPairsCommand(SolverCommandMixin, Command):
                                 reaction.equation, compound_formula, solver,
                                 weight_func=element_weight))
                 if self._args.ambiguous:
-                    print('TRANSFER-LIST', reaction.id, transfer)
                     if len(transfer) > 1:
                         ambiguous.add(reaction.id)
             except mapmaker.UnbalancedReactionError:

--- a/psamm/findprimarypairs.py
+++ b/psamm/findprimarypairs.py
@@ -202,6 +202,9 @@ def predict_compound_pairs_iterated(
     final_ambiguous_reactions = {}
 
     def print_ambiguous_summary():
+        '''Function for summarizing and printing ambiguous compound pairs
+
+        '''
         final_ambiguous_count = 0
         final_ambiguous_hydrogen = 0
         for reaction, pairs in sorted(iteritems(final_ambiguous_reactions)):

--- a/psamm/findprimarypairs.py
+++ b/psamm/findprimarypairs.py
@@ -252,9 +252,9 @@ def predict_compound_pairs_iterated(
                 rpairs.setdefault((c1, c2), []).append(form)
 
             prediction[reaction_id] = rpairs, balance
-
-        logger.info('Ambiguous Reactions:')
-        print_ambiguous_summary()
+        if ambiguous is True:
+            logger.info('Ambiguous Reactions:')
+            print_ambiguous_summary()
 
         pairs_predicted = Counter()
         for reaction_id, (rpairs, _) in iteritems(prediction):

--- a/psamm/findprimarypairs.py
+++ b/psamm/findprimarypairs.py
@@ -24,6 +24,8 @@ from collections import Counter
 from six import iteritems
 from six.moves import reduce
 
+import random
+
 from .formula import Formula, Atom
 
 try:
@@ -154,7 +156,7 @@ class _CompoundInstance(object):
 
 
 def predict_compound_pairs_iterated(
-        reactions, formulas, prior=(1, 43), max_iterations=None,
+        reactions, formulas, ambiguous, prior=(1, 43), max_iterations=None,
         element_weight=element_weight):
     """Predict reaction pairs using iterated method.
 
@@ -168,6 +170,8 @@ def predict_compound_pairs_iterated(
         reactions: Dictionary or pair-iterable of (id, equation) pairs.
             IDs must be any hashable reaction identifier (e.g. string) and
             equation must be :class:`psamm.reaction.Reaction` objects.
+        ambiguous: True or False value to indicate if the ambiguous
+            reactions should be printed in the debugging output.
         formulas: Dictionary mapping compound IDs to
             :class:`psamm.formula.Formula`. Formulas must be flattened.
         prior: Tuple of (alpha, beta) parameters for the MAP inference.
@@ -186,11 +190,40 @@ def predict_compound_pairs_iterated(
 
     pair_reactions = {}
     possible_pairs = Counter()
+    tie_breakers = {}
     for reaction_id, equation in iteritems(reactions):
+        tie_breakers[reaction_id] = {}
         for (c1, _), (c2, _) in product(equation.left, equation.right):
             spair = tuple(sorted([c1.name, c2.name]))
             possible_pairs[spair] += 1
             pair_reactions.setdefault(spair, set()).add(reaction_id)
+            #tie_breakers[reaction_id][spair] = random.random()
+
+    final_ambiguous_reactions = {}
+
+    def print_ambiguous_summary():
+        final_ambiguous_count = 0
+        final_ambiguous_hydrogen = 0
+        for reaction, pairs in sorted(iteritems(final_ambiguous_reactions)):
+            all_hydrogen = False
+            if len(pairs) > 0:
+                final_ambiguous_count += 1
+                all_hydrogen = True
+
+            for pair in pairs:
+                for _, _, formula in pair:
+                    df = dict(formula.items())
+                    if len(df) > 1 or Atom.H not in df:
+                        all_hydrogen = False
+                logger.info('Ambiguous Transfers in Reaction: {}'.format(reaction))
+
+            if all_hydrogen:
+                final_ambiguous_hydrogen += 1
+
+        logger.info('{} reactions were decided with ambiguity'.format(
+            final_ambiguous_count))
+        logger.info('Only hydrogen in decision: {} vs non hydrogen: {}'.format(
+            final_ambiguous_hydrogen, final_ambiguous_count - final_ambiguous_hydrogen))
 
     next_reactions = set(reactions)
     pairs_predicted = None
@@ -211,13 +244,17 @@ def predict_compound_pairs_iterated(
             if result is None:
                 continue
 
-            transfer, balance = result
+            transfer, balance, ambiguous_pairs = result
+            final_ambiguous_reactions[reaction_id] = ambiguous_pairs
 
             rpairs = {}
             for ((c1, _), (c2, _)), form in iteritems(transfer):
                 rpairs.setdefault((c1, c2), []).append(form)
 
             prediction[reaction_id] = rpairs, balance
+
+        logger.info('Ambiguous Reactions:')
+        print_ambiguous_summary()
 
         pairs_predicted = Counter()
         for reaction_id, (rpairs, _) in iteritems(prediction):
@@ -258,6 +295,7 @@ def _match_greedily(reaction, compound_formula, score_func):
             returns the score.
     """
     uninstantiated_left, uninstantiated_right = _reaction_to_dicts(reaction)
+    ambiguous_pairs = set()
 
     def compound_instances(uninstantiated):
         instances = []
@@ -302,12 +340,29 @@ def _match_greedily(reaction, compound_formula, score_func):
         (inst1, inst2), score = entry
         c1, c2 = inst1.compound, inst2.compound
         same_compound = c1.name == c2.name and c1.compartment != c2.compartment
+        key = tuple(sorted([c1.name, c2.name]))
         return same_compound, score, c1.name, c2.name
 
     transfer = {}
     while len(pairs) > 0:
         (inst1, inst2), _ = max(iteritems(pairs), key=inst_pair_sort_key)
         common = inst1.formula & inst2.formula
+        sorted_pairs = sorted(iteritems(pairs), key=inst_pair_sort_key, reverse=True)
+        max_sort_key = inst_pair_sort_key(sorted_pairs[0])
+
+        ambiguous_entry = {(inst1.compound, inst2.compound, common)}
+        for (other_inst1, other_inst2), other_score in sorted_pairs[1:]:
+            other_sort_key = inst_pair_sort_key(
+                ((other_inst1, other_inst2), other_score))
+            if other_sort_key[:2] < max_sort_key[:2]:
+                break
+
+            other_common = other_inst1.formula & other_inst2.formula
+            ambiguous_entry.add(
+                (other_inst1.compound, other_inst2.compound, other_common))
+
+        if len(ambiguous_entry) > 1:
+            ambiguous_pairs.add(tuple(ambiguous_entry))
 
         key = (inst1.compound, inst1.index), (inst2.compound, inst2.index)
         if key not in transfer:
@@ -360,7 +415,7 @@ def _match_greedily(reaction, compound_formula, score_func):
             key = inst.compound, inst.index
             balance[key] = inst.formula
 
-    return transfer, balance
+    return transfer, balance, ambiguous_pairs
 
 
 def predict_compound_pairs(reaction, compound_formula, pair_weights={},


### PR DESCRIPTION
An update the the primarypairs functions in psamm to allow for the printing of reactions that have ambiguous compound pairing. 