### PR TITLE
Change pd.append to pd.concat for pandas 2.0

### DIFF
--- a/psamm/manual_curation.py
+++ b/psamm/manual_curation.py
@@ -193,7 +193,7 @@ def read_mapping(file, index_col):
 
 
 def add_mapping(map, row):
-    return map.append(pd.DataFrame(row).T)
+    return pd.concat([map, pd.DataFrame(row).T])
 
 
 def read_ignore(file):


### PR DESCRIPTION
Since pandas 2.0, pd.append is no longer supported, which leads to a broken manual_curation function. 
It can be easily fixed by migrating to pd.concat.

Greetings from Jing!